### PR TITLE
Test cat table

### DIFF
--- a/brachyutils/geometry/__init__.py
+++ b/brachyutils/geometry/__init__.py
@@ -7,9 +7,10 @@ __all__ = [
     "DwellPosition",
     "Catheter",
     "CatheterTable",
+    "get_uniform_phantom",
 ]
 # trunk-ignore(ruff/F401)
-from .phantom_utils import BrachyPhantom
+from .phantom_utils import BrachyPhantom, get_uniform_phantom
 
 # trunk-ignore(ruff/F401)
 from .egsphant_utils import BrachyEgsphant

--- a/brachyutils/geometry/catheter_utils.py
+++ b/brachyutils/geometry/catheter_utils.py
@@ -91,6 +91,12 @@ class Catheter(BaseModel):
     - This class holds the information regarding a catheter. The first catheter is placed at the 
     tip position and extends back towards the insertion point. The last dwell position is placed
     at the last_dwell_coordinate.
+    
+    To initiate a catheter, you can provide either of the following:
+    1. tip_position and last_dwell_coordinate
+    2. digitization points
+    3. fit_function
+    4. dwells
 
     ### Attributes:
     - index:int := the index of the catheter.
@@ -155,7 +161,7 @@ class Catheter(BaseModel):
                 fit_function=all_inputs["fit_function"],
                 step_size=all_inputs.get("step_size",5.0),
                 )
-        # create the fit and dwells from points
+        # create the fit and digitization from points
         elif all_inputs.get("points", None) is not None:
             all_inputs["fit_function"] = cls.get_fit_from_points(
                 points=all_inputs["points"],

--- a/brachyutils/geometry/catheter_utils.py
+++ b/brachyutils/geometry/catheter_utils.py
@@ -420,6 +420,31 @@ class CatheterTable(BaseModel):
         with open(pth_json, "w") as json_file:
             json.dump(self.to_dict(), json_file, indent=4
             )
+    def write_to_slicer_markup(self, pth_mrk_json: Path | str, **kwargs) -> None:
+        r"""
+        ### Purpose:
+        - Write the catheter table to a json file in the slicer markup format.
+        
+        ### Inputs:
+        - pth_json: Path := the path to the json file where the catheter table will be written.
+        
+        ### Outputs:
+        - Void := will write the catheter table to a json file in the slicer markup format.
+        """
+        from ai_assisted_brachy.preprocessing.utils import create_slicer_markup_segments
+        pth_mrk_json = Path(pth_mrk_json)
+        if not str(pth_mrk_json).endswith(".mrk.json"):
+            raise ValueError("The output file name should end with .mrk.json")
+        pth_mrk_json.parent.mkdir(parents=True, exist_ok=True)
+
+        point_list = [catheter.points for catheter in self]
+        
+        create_slicer_markup_segments(
+            output_path=pth_mrk_json,
+            point_list=point_list,
+            color=kwargs.get("color", None),
+            remove_text=kwargs.get("remove_text", True),
+        )
 
     @classmethod
     def load_from_json(cls, pth_json: Path) -> list:

--- a/brachyutils/geometry/catheter_utils.py
+++ b/brachyutils/geometry/catheter_utils.py
@@ -439,7 +439,7 @@ class CatheterTable(BaseModel):
         ### Outputs:
         - Void := will write the catheter table to a json file in the slicer markup format.
         """
-        from ai_assisted_brachy.preprocessing.utils import create_slicer_markup_segments
+        from ai_assisted_brachy.preprocessing.utils import create_slicer_markup_points
         pth_mrk_json = Path(pth_mrk_json)
         if not str(pth_mrk_json).endswith(".mrk.json"):
             raise ValueError("The output file name should end with .mrk.json")
@@ -447,8 +447,8 @@ class CatheterTable(BaseModel):
 
         point_list = [catheter.points for catheter in self]
         
-        create_slicer_markup_segments(
-            output_path=pth_mrk_json,
+        create_slicer_markup_points(
+            output_path=str(pth_mrk_json),
             point_list=point_list,
             color=kwargs.get("color", None),
             remove_text=kwargs.get("remove_text", True),

--- a/brachyutils/geometry/catheter_utils.py
+++ b/brachyutils/geometry/catheter_utils.py
@@ -88,14 +88,21 @@ class DwellPosition(BaseModel):
 class Catheter(BaseModel):
     r"""
     ### Purpose:
-    - This class holds the information regarding a catheter.
-    
+    - This class holds the information regarding a catheter. The first catheter is placed at the 
+    tip position and extends back towards the insertion point. The last dwell position is placed
+    at the last_dwell_coordinate.
+
     ### Attributes:
     - index:int := the index of the catheter.
+    - tip_position: The coordinate position of the tip of the catheter.
     - points:List[np.array] := the list of digitization points of the catheter.
     - dwells:List[DwellPosition] := the list of dwell positions of the catheter.
     - afterloader_channel_number:int := the afterloader channel number of the catheter.
     - channel_total_time:float := the total time of the catheter.
+    - step_size: float := distance between the subsequent dwell positions.
+    - fit_function:PiecewiseLinear3D := a line that connects the dwell positions together.
+    - insert_position:list := The coordinates on patient body or insertion grid where the 
+    catheter was inserted from.
 
     ### Functions:
     - to_dict() -> dict := convert the catheter to a dictionary.
@@ -106,7 +113,7 @@ class Catheter(BaseModel):
     # in case dwells are missing and fit, tip, last dwell position and step size is provided
     fit_function:Any = None
     tip_position: List[float] = None
-    last_dwell_position: List[float] = None
+    last_dwell_coordinate: List[float] = None
     step_size: float = 5.0
     # in case dwells and fit is missing and digitization points are provided.
     # we assume tip is the first digitization point and last dwell is the last digitization point.
@@ -146,7 +153,7 @@ class Catheter(BaseModel):
         elif all_inputs.get("fit_function", None) is not None:
             all_inputs["dwells"] = cls.get_dwells_from_fit(
                 fit_function=all_inputs["fit_function"],
-                step_size=all_inputs.get("step_size"),
+                step_size=all_inputs.get("step_size",5.0),
                 )
         # create the fit and dwells from points
         elif all_inputs.get("points", None) is not None:
@@ -155,24 +162,24 @@ class Catheter(BaseModel):
             )
             all_inputs["dwells"] = cls.get_dwells_from_fit(
                 fit_function=all_inputs["fit_function"],
-                step_size=all_inputs.get("step_size"),
+                step_size=all_inputs.get("step_size",5.0),
             )
         elif (all_inputs.get("tip_position", None) is not None
-              and all_inputs.get("last_dwell_position", None) is not None
+              and all_inputs.get("last_dwell_coordinate", None) is not None
         ):
             all_inputs["fit_function"] = cls.get_fit_from_points(
-                points=[all_inputs["tip_position"], all_inputs["last_dwell_position"]],
+                points=[all_inputs["tip_position"], all_inputs["last_dwell_coordinate"]],
             )
             all_inputs["dwells"] = cls.get_dwells_from_fit(
                 fit_function=all_inputs["fit_function"],
-                step_size=all_inputs.get("step_size"),
+                step_size=all_inputs.get("step_size",5.0),
             )
         else:
-            raise ValueError("Either provide dwells, fit_function, points or\
-                tip and last dwell position coordinates to the create a catheter.")
+            raise ValueError("""Either provide dwells, fit_function, points or
+            tip and last dwell coordinate coordinates to the create a catheter.""")
 
         all_inputs["tip_position"] = all_inputs["dwells"][0].position
-        all_inputs["last_dwell_position"] = all_inputs["dwells"][-1].position
+        all_inputs["last_dwell_coordinate"] = all_inputs["dwells"][-1].position
 
         return all_inputs
 
@@ -196,7 +203,7 @@ class Catheter(BaseModel):
             "dwells": [dwell.to_dict(total_time) for dwell in self.dwells],
             # "fit_function": self.fit_function,
             "tip_position": self.tip_position,
-            "last_dwell_position": self.last_dwell_position,
+            "last_dwell_coordinate": self.last_dwell_coordinate,
             "step_size": self.step_size,
             "points": self.points,
             "afterloader_channel_number": self.afterloader_channel_number,

--- a/brachyutils/geometry/catheter_utils.py
+++ b/brachyutils/geometry/catheter_utils.py
@@ -352,11 +352,19 @@ class CatheterTable(BaseModel):
             ):
             catheter_file = Path(all_inputs["catheter_list"])
 
+            if not catheter_file.exists():
+                raise ValueError(f"catheter file {catheter_file} does not exist.")
+            if str(catheter_file).endswith(".mrk.json"):
+                # if the file is a slicer markup file, load it as a json file
+                raise NotImplementedError("this feature is not implemented yet.")
+
             if str(catheter_file).endswith(".json"):
                 cat_dict = cls.load_from_json(catheter_file)
 
             elif str(catheter_file).endswith(".dcm"):
                 cat_dict = cls.load_from_dicom(pth_dicom=catheter_file)
+            elif catheter_file.is_dir():
+                cat_dict = cls.load_from_dicom(pth_dicom=catheter_file, from_ct=True)
 
             all_inputs["catheter_list"] = cat_dict["catheter_list"]
             all_inputs["step_size"] = cat_dict["step_size"]

--- a/brachyutils/geometry/catheter_utils.py
+++ b/brachyutils/geometry/catheter_utils.py
@@ -345,9 +345,9 @@ class CatheterTable(BaseModel):
             elif str(catheter_file).endswith(".dcm"):
                 cat_dict = cls.load_from_dicom(pth_dicom=catheter_file)
 
-        all_inputs["catheter_list"] = cat_dict["catheter_list"]
-        all_inputs["step_size"] = cat_dict["step_size"]
-        all_inputs["channel_length"] = cat_dict["channel_length"]
+            all_inputs["catheter_list"] = cat_dict["catheter_list"]
+            all_inputs["step_size"] = cat_dict["step_size"]
+            all_inputs["channel_length"] = cat_dict["channel_length"]
 
         if isinstance(all_inputs["catheter_list"][0], dict):
             all_inputs["catheter_list"] = [

--- a/brachyutils/geometry/egsphant_utils.py
+++ b/brachyutils/geometry/egsphant_utils.py
@@ -65,7 +65,7 @@ class BrachyEgsphant:
         pth_egsphant_file: Optional[Path] = None,
         phantom: Optional[Union[BrachyPhantom | Path]] = None,
         material_dict: Optional[Union[dict, Path]] = None,
-        assign_material_from_ct: Optional[bool] = None,
+        assign_material_from_ct: Optional[bool] = True,
         background_material: Optional[str] = "Air",
     ) -> None:
         r"""
@@ -132,9 +132,25 @@ class BrachyEgsphant:
                 assign_material_from_ct=assign_material_from_ct,
                 background_material = background_material
             )
+        elif phantom is not None and material_dict is None:
+            if not assign_material_from_ct:
+                raise Exception(
+                    "No material dict is provided. can only assign material of every voxel to air"
+                )
+            self.create_egsphant_from_phantom(
+                phantom_obj=(
+                    phantom
+                    if isinstance(phantom, BrachyPhantom)
+                    else BrachyPhantom(phantom)
+                ),
+                new_material_dict=self.material_dict,
+                assign_material_from_ct=assign_material_from_ct,
+                background_material = background_material
+            )
+
         else:
             raise Exception(
-                "Either provide a path to an egsphant file or a dicom image and a material dictionary"
+                "Either provide a path to an egsphant file or a phantom and a material dictionary"
             )
 
     def load_file_to_BrachyEgsphant(self, pth_egsphant_file):

--- a/brachyutils/geometry/phantom_utils.py
+++ b/brachyutils/geometry/phantom_utils.py
@@ -1,5 +1,3 @@
-
-
 import warnings
 import os
 import numpy as np
@@ -1135,6 +1133,40 @@ def phantom_with_empty_image_like(
     new_phantom.xyz_format = phantom.xyz_format
 
     return new_phantom
+
+def get_uniform_phantom(
+    voxel_value: float = 0.0,
+    gridSize: List[int] = [100, 100, 100],
+    spacing: List[float] = [1.0, 1.0, 1.0],
+    origin: List[float] = [0.0, 0.0, 0.0],
+    )-> BrachyPhantom:
+    r"""
+    ### Purpose:
+    - Create a uniform cubic phantom object where all the voxels have the same value.
+
+    ### Inputs:
+    - voxel_value: float := the value of the voxels in the phantom.
+    - gridSizeInMilimeters: List[int] := the size of the phantom in millimeters.
+    - spacing: List[float] := the spacing of the phantom in millimeters.
+    - origin: List[float] := the origin of the phantom in millimeters.
+
+    ### Outputs:
+    - phantom: BrachyPhantom := the new phantom object.
+    """
+    phantom = BrachyPhantom()
+    phantom.image_obj = Image3D(
+        imageArray=np.ones(gridSize) * voxel_value,
+        spacing=spacing,
+        origin=origin,
+    )
+    phantom.image_modality = None
+    phantom.structure_set = None
+    phantom.structure_names = []
+    phantom.unit_length = "cm"
+    phantom.xyz_format = "LPS"
+
+    return phantom
+    
 
 def _sort_segementation_dict_by_size(seg_dict) -> dict:
     r"""

--- a/brachyutils/planning/plan_utils.py
+++ b/brachyutils/planning/plan_utils.py
@@ -379,7 +379,7 @@ class BrachyPlan:
         # extract the attributes above from the catheter table
         dwell_counter = 1
         for catheter in self.catheter_table.catheter_list:
-            self.catheter_numbers = np.append(self.catheter_numbers, catheter.iD)
+            self.catheter_numbers = np.append(self.catheter_numbers, catheter.index)
             for dwell in catheter.dwells:
                 self.dwell_numbers = np.append(self.dwell_numbers, dwell_counter)
                 self.dwell_times = np.append(self.dwell_times, dwell.time)
@@ -389,7 +389,7 @@ class BrachyPlan:
                         "position": dwell.position,
                         "rotation": dwell.rotation,
                         "relativePos": dwell.relativePos,
-                        "catheterId": catheter.iD,
+                        "catheterId": catheter.index,
                     }
                 )
                 dwell_counter += 1

--- a/brachyutils/planning/simulation_utils.py
+++ b/brachyutils/planning/simulation_utils.py
@@ -1,13 +1,13 @@
 import json
 from pathlib import Path
-from typing import Union
+from typing import Union, Literal
 import pydicom
 from collections import defaultdict
 
 class BrachySource:
     def __init__(
         self,
-        treatment_type: str = "HDR",
+        treatment_type: Literal["HDR", "PLDR", "TLDR"] = "HDR",
         source_geometry: str = "MicroSelectronV2",
         core_material: str = "G4_Ir",
         mass_number: int = 192,

--- a/brachyutils/tests/test_cli_utils.py
+++ b/brachyutils/tests/test_cli_utils.py
@@ -27,13 +27,13 @@ from brachyutils.dose_utils import BrachyDose
 
 def test_crop_egsphant_by_body_contour_many_patients():
     # test on testing dataset
-    pth_input = "../../data_test/prostate-glen-p1-planFiles/"
-    pth_json = "../../data_test/test_patient_body_bounds.json"
+    pth_input = "data_test/prostate-glen-p1-planFiles/"
+    pth_json = "data_test/test_patient_body_bounds.json"
     crop_egsphant_by_body_contour_many_patients(pth_input, pth_json)
 
 
 def test_convert_many_files():
-    dir_in = "../../data_test/many_files/"
+    dir_in = "data_test/many_files/"
     type_in = ".nrrd"
     type_out = ".minidos"
 
@@ -54,14 +54,14 @@ def test_convert_many_files():
 
 
 def test_crop_dose_by_body_contour_many_files():
-    pth_3ddose = "../../data_test/3ddose/p1"
-    pth_json = "../../data_test/patient_body_bounds.json"
+    pth_3ddose = "data_test/3ddose/p1"
+    pth_json = "data_test/patient_body_bounds.json"
 
     crop_dose_by_body_contour_many_files(pth_3ddose, pth_json)
 
 
 def test_combined_dose_per_patient():
-    batch_directory = "../../data_test/batch_uncertainty_test/"
+    batch_directory = "data_test/batch_uncertainty_test/"
     combined_dose_per_patient(batch_directory, ".3ddose", ".3ddose", multi_proc=True)
     mp_combined = BrachyDose(f"{batch_directory}/combined.3ddose")
     combined_dose_per_patient(batch_directory, ".3ddose", ".3ddose", multi_proc=False)

--- a/brachyutils/tests/test_cli_utils.py
+++ b/brachyutils/tests/test_cli_utils.py
@@ -14,8 +14,8 @@ from brachyutils.dose_utils import BrachyDose
 
 
 # def test_get_body_contour_range_from_dicom_many_patients():
-#     input_dir = "../data_test"
-#     pth_json = "../data_test/test_export_plan/patient_body_bounds_output.json"
+#     input_dir = "data_test"
+#     pth_json = "data_test/test_export_plan/patient_body_bounds_output.json"
 
 #     get_body_contour_range_from_dicom_many_patients(input_dir, pth_json)
 

--- a/brachyutils/tests/test_dose_generation_utils.py
+++ b/brachyutils/tests/test_dose_generation_utils.py
@@ -7,15 +7,15 @@ from brachyutils.plan_utils import BrachyPlan
 
 
 def make_plan_and_export_it(dir_export) -> Path:
-    pth_cathTable_json = "../data_test/prostate-glen-p1-planFiles/catheter_table.json"
-    dir_dose_rate = "../data_test/prostate-glen-p1-dose"
-    dir_dicom = "../data_test/prostate-glen-p1-dcm/"
+    pth_cathTable_json = "data_test/prostate-glen-p1-planFiles/catheter_table.json"
+    dir_dose_rate = "data_test/prostate-glen-p1-dose"
+    dir_dicom = "data_test/prostate-glen-p1-dcm/"
     pth_combined_dose = glob(dir_dicom + "/RD*.dcm")[0]
-    # dir_egsphant = "../data_test/prostate-glen-p1-planFiles/ct.egsphant"
+    # dir_egsphant = "data_test/prostate-glen-p1-planFiles/ct.egsphant"
     # # assign material based on contours:
-    # pth_material = "../data_test/prostate_material_dict.json"
+    # pth_material = "data_test/prostate_material_dict.json"
     # # assign materials based on CT values:
-    pth_material = "../data_test/CTtoDensityProstate.txt"
+    pth_material = "data_test/CTtoDensityProstate.txt"
     dvh_metric_goals = {
         "D95%(ctv)": 15,
         "D1cc(rectum)": 11.25,
@@ -39,7 +39,7 @@ def make_plan_and_export_it(dir_export) -> Path:
         "PrintProgress": 10000,
         "beam_on": 10000,
     }
-    # dir_export = "../data_test/test_export_plan"
+    # dir_export = "data_test/test_export_plan"
     export_format = "RapidBrachy"
     os.makedirs(dir_export, exist_ok=True)
 
@@ -73,7 +73,7 @@ def make_plan_and_export_it(dir_export) -> Path:
 
 
 def test_DoseTG43():
-    dir_export = "../temp_data/tg43/p1"
+    dir_export = "temp_data/tg43/p1"
     dose_setup = make_plan_and_export_it(dir_export)
     dose_setup = Path("temp_data/tg43/p1")
     pth_exectuable = "http://192.168.1.12:8000/calculate_dose_tg43"
@@ -86,7 +86,7 @@ def test_DoseTG43():
 
 
 def test_DoseMC():
-    dir_export = "../temp_data/mc/p1"
+    dir_export = "temp_data/mc/p1"
     dose_setup = make_plan_and_export_it(dir_export)
     dose_setup = Path("temp_data/mc/p1")
     pth_exectuable = "http://192.168.1.11:8000/calculate_dose_mc"

--- a/brachyutils/tests/test_dose_utils.py
+++ b/brachyutils/tests/test_dose_utils.py
@@ -49,7 +49,7 @@ def test_load_from_dicom():
 
 
 def test_write_to_3ddose():
-    # pth_3ddose =  "../../data_test/run_1_old.3ddose"
+    # pth_3ddose =  "data_test/run_1_old.3ddose"
 
     # testing on maude's file
     pth_file = "../data_test/rectal-jgh-planFiles/combined.3ddose"
@@ -92,10 +92,10 @@ def test_convert_to_npz_file():
     Purpose:
         simulatenously test write_to_npz() and load_from_npz()
     """
-    # pth_3ddose =  "../../data_test/combined.3ddose"
+    # pth_3ddose =  "data_test/combined.3ddose"
 
     # testing on maude's file
-    pth_3ddose = "../../data_test/maude.3ddose"
+    pth_3ddose = "data_test/maude.3ddose"
     pth_out = os.path.splitext(pth_3ddose)[0] + ".npz"
     dose_obj = BrachyDose()
     dose_obj.load_file_to_brachydose(pth_3ddose)
@@ -109,10 +109,10 @@ def test_convert_to_npz_file():
 
 def test_write_to_xz():
 
-    # pth_3ddose =  "../../data_test/combined.3ddose"
+    # pth_3ddose =  "data_test/combined.3ddose"
 
     # testing on maude's file
-    pth_3ddose = "../../data_test/maude.3ddose"
+    pth_3ddose = "data_test/maude.3ddose"
     pth_out = os.path.splitext(pth_3ddose)[0] + ".xz"
     dose_obj = BrachyDose()
     dose_obj.load_file_to_brachydose(pth_3ddose)
@@ -122,11 +122,11 @@ def test_write_to_xz():
 
 def test_write_to_zstd():
 
-    # pth_3ddose =  "../../data_test/combined.3ddose"
-    # pth_zstd = "../../data_test/combined.zst"
+    # pth_3ddose =  "data_test/combined.3ddose"
+    # pth_zstd = "data_test/combined.zst"
 
     # testing on maude's file
-    pth_3ddose = "../../data_test/maude.3ddose"
+    pth_3ddose = "data_test/maude.3ddose"
     pth_out = os.path.splitext(pth_3ddose)[0] + ".zst"
     print(pth_out)
     dose_obj = BrachyDose()
@@ -137,7 +137,7 @@ def test_write_to_zstd():
 
 def test_crop_by_coordinates():
     pth_input = "../data_test/rectal-jgh-planFiles/combined.3ddose"
-    # pth_input = "../../data_test/prostate-glen-p1-dose/scaled_run_1.nrrd"
+    # pth_input = "data_test/prostate-glen-p1-dose/scaled_run_1.nrrd"
     dose_obj = BrachyDose(pth_input)
     dose_obj.info()
 
@@ -149,7 +149,7 @@ def test_crop_by_coordinates():
 
 def test_crop_by_index():
     pth_input = "../data_test/rectal-jgh-planFiles/combined.3ddose"
-    # pth_input = "../../data_test/prostate-glen-p1-dose/scaled_run_1.nrrd"
+    # pth_input = "data_test/prostate-glen-p1-dose/scaled_run_1.nrrd"
     dose_obj = BrachyDose(pth_input)
     dose_obj.info()
 
@@ -162,7 +162,7 @@ def test_crop_by_index():
 
 def test_crop_by_fraction():
     pth_input = "../data_test/rectal-jgh-planFiles/combined.3ddose"
-    # pth_input = "../../data_test/prostate-glen-p1-dose/scaled_run_1.nrrd"
+    # pth_input = "data_test/prostate-glen-p1-dose/scaled_run_1.nrrd"
     dose_obj = BrachyDose(pth_input)
     dose_obj.info()
 
@@ -173,7 +173,7 @@ def test_crop_by_fraction():
 
 
 def test_convert_to_minidos():
-    pth_input = "../../data_test/dwell1_1mm.nrrd"
+    pth_input = "data_test/dwell1_1mm.nrrd"
     pth_minidos = os.path.splitext(pth_input)[0] + ".minidos"
     dose_obj = BrachyDose()
     dose_obj.load_file_to_brachydose(pth_input)
@@ -182,8 +182,8 @@ def test_convert_to_minidos():
 
 def test_dose_comparison():
     logging.basicConfig(stream=sys.stdout, level=logging.DEBUG)
-    pth_3ddose = "../../data_test/run_1_old.3ddose"
-    pth_3ddose2 = "../../data_test/run_1_old.3ddose"
+    pth_3ddose = "data_test/run_1_old.3ddose"
+    pth_3ddose2 = "data_test/run_1_old.3ddose"
     dose_obj = BrachyDose()
     dose_obj.load_file_to_brachydose(pth_3ddose)
     dose_obj2 = BrachyDose()

--- a/brachyutils/tests/test_dose_utils.py
+++ b/brachyutils/tests/test_dose_utils.py
@@ -10,8 +10,8 @@ from pathlib import Path
 from brachyutils.geometry_utils import BrachyPhantom
 
 def make_dose_from_image():
-    pth_dicom = Path("../data_test/prostate-glen-p1-dcm")
-    pth_dose_nrrd = Path("../data_test/test_export_plan/dose_image.seq.nrrd")
+    pth_dicom = Path("data_test/prostate-glen-p1-dcm")
+    pth_dose_nrrd = Path("data_test/test_export_plan/dose_image.seq.nrrd")
 
     image = BrachyPhantom(
         dir_dicom=pth_dicom,
@@ -26,7 +26,7 @@ def make_dose_from_image():
     dose.write_to_nrrd(pth_dose_nrrd)
 
 def test_load_from_3ddose():
-    pth_file = "../data_test/rectal-jgh-planFiles/combined.3ddose"
+    pth_file = "data_test/rectal-jgh-planFiles/combined.3ddose"
 
     dose_obj = BrachyDose()
     dose_obj.load_from_3ddose(pth_file)
@@ -35,14 +35,14 @@ def test_load_from_3ddose():
 
 
 def test_load_file_to_brachydose():
-    pth_3ddose = "../data_test/run_1_old.3ddose"
+    pth_3ddose = "data_test/run_1_old.3ddose"
     dose_obj = BrachyDose()
     dose_obj.load_file_to_brachydose(pth_3ddose)
     dose_obj.is_not_empty()
 
 
 def test_load_from_dicom():
-    pth_dicom = "../data_test/prostate-glen-p1-dcm/RD1.3.6.1.4.1.2452.6.350102904.1117384417.1751574951.1257637737.dcm"
+    pth_dicom = "data_test/prostate-glen-p1-dcm/RD1.3.6.1.4.1.2452.6.350102904.1117384417.1751574951.1257637737.dcm"
     dose_obj = BrachyDose(pth_dicom)
     dose_obj.info()
     dose_obj.is_not_empty()
@@ -52,8 +52,8 @@ def test_write_to_3ddose():
     # pth_3ddose =  "data_test/run_1_old.3ddose"
 
     # testing on maude's file
-    pth_file = "../data_test/rectal-jgh-planFiles/combined.3ddose"
-    dir_out = "../data_test/test_export_plan"
+    pth_file = "data_test/rectal-jgh-planFiles/combined.3ddose"
+    dir_out = "data_test/test_export_plan"
 
     dose_obj = BrachyDose(pth_file)
 
@@ -65,8 +65,8 @@ def test_write_to_3ddose():
 
 
 def test_load_from_nrrd():
-    pth_input = "../data_test/new_nrrd/PreOptimization/run_1_1_0.nrrd"
-    # pth_input = "../data_test/prostate-glen-p1-dose/scaled_run_1.nrrd"
+    pth_input = "data_test/new_nrrd/PreOptimization/run_1_1_0.nrrd"
+    # pth_input = "data_test/prostate-glen-p1-dose/scaled_run_1.nrrd"
 
     dose_obj = BrachyDose(pth_input)
     dose_obj.info()
@@ -77,9 +77,9 @@ def test_write_to_nrrd():
     Purpose:
         simulatenously test write_to_nrrd() and load_from_nrrd()
     """
-    pth_out = "../data_test/test_export_plan"
-    pth_input = "../data_test/prostate-glen-p1-planFiles/dose_image.seq.nrrd"
-    # pth_input = "../data_test/new_nrrd/P5Fx1_tra/combined.nrrds"
+    pth_out = "data_test/test_export_plan"
+    pth_input = "data_test/prostate-glen-p1-planFiles/dose_image.seq.nrrd"
+    # pth_input = "data_test/new_nrrd/P5Fx1_tra/combined.nrrds"
     pth_out = os.path.join(pth_out, "test_"+os.path.basename(pth_input))
     dose_obj = BrachyDose(pth_input)
     dose_obj.write_to_nrrd(pth_out)
@@ -136,7 +136,7 @@ def test_write_to_zstd():
 
 
 def test_crop_by_coordinates():
-    pth_input = "../data_test/rectal-jgh-planFiles/combined.3ddose"
+    pth_input = "data_test/rectal-jgh-planFiles/combined.3ddose"
     # pth_input = "data_test/prostate-glen-p1-dose/scaled_run_1.nrrd"
     dose_obj = BrachyDose(pth_input)
     dose_obj.info()
@@ -148,7 +148,7 @@ def test_crop_by_coordinates():
 
 
 def test_crop_by_index():
-    pth_input = "../data_test/rectal-jgh-planFiles/combined.3ddose"
+    pth_input = "data_test/rectal-jgh-planFiles/combined.3ddose"
     # pth_input = "data_test/prostate-glen-p1-dose/scaled_run_1.nrrd"
     dose_obj = BrachyDose(pth_input)
     dose_obj.info()
@@ -161,7 +161,7 @@ def test_crop_by_index():
 
 
 def test_crop_by_fraction():
-    pth_input = "../data_test/rectal-jgh-planFiles/combined.3ddose"
+    pth_input = "data_test/rectal-jgh-planFiles/combined.3ddose"
     # pth_input = "data_test/prostate-glen-p1-dose/scaled_run_1.nrrd"
     dose_obj = BrachyDose(pth_input)
     dose_obj.info()
@@ -196,9 +196,9 @@ def test_dose_comparison():
 
 
 def test_crop_by_dicom_structure():
-    pth_dicomRS = "../data_test/rectal-jgh-dcm/"
-    pth_input = "../data_test/rectal-jgh-planFiles/combined.3ddose"
-    # dir_out = "../data_test/test_export_plan"
+    pth_dicomRS = "data_test/rectal-jgh-dcm/"
+    pth_input = "data_test/rectal-jgh-planFiles/combined.3ddose"
+    # dir_out = "data_test/test_export_plan"
 
     dose_obj = BrachyDose(pth_input)
     dose_obj.info()

--- a/brachyutils/tests/test_egsphant_utils.py
+++ b/brachyutils/tests/test_egsphant_utils.py
@@ -75,7 +75,7 @@ def test_write_to_nrrd():
 
 
 def test_to_single_string():
-    pth_input = "../../data_test/prostate-glen-p1-planFiles/ct.egsphant"
+    pth_input = "data_test/prostate-glen-p1-planFiles/ct.egsphant"
     # pth_output = os.path.dirname(pth_input) + "/test_"+os.path.basename(pth_input)
 
     egsphant_obj = BrachyEgsphant()
@@ -93,7 +93,7 @@ def test_load_from_ctegsphant():
 
 
 def test_load_from_nrrd():
-    pth_input = "../../data_test/prostate-glen-p1-planFiles/ct.nrrd"
+    pth_input = "data_test/prostate-glen-p1-planFiles/ct.nrrd"
 
     egsphant_obj = BrachyEgsphant()
     egsphant_obj.load_from_nrrd(pth_input)
@@ -140,7 +140,7 @@ def test_create_egsphant_from_images():
 
 
 def text_load_material_dict():
-    pth_input = "../../data_test/prostate-glen-p1-dcm/CTtoDensityProstate.txt"
+    pth_input = "data_test/prostate-glen-p1-dcm/CTtoDensityProstate.txt"
     materials_dict = _load_material_dict(pth_input)
     print(materials_dict)
 

--- a/brachyutils/tests/test_egsphant_utils.py
+++ b/brachyutils/tests/test_egsphant_utils.py
@@ -15,10 +15,10 @@ from brachyutils.egsphant_utils import (
 
 
 def test_crop_by_dicom_structure():
-    pth_dicomRS = "../data_test/prostate-glen-p1-dcm/"
+    pth_dicomRS = "data_test/prostate-glen-p1-dcm/"
     # print("pth_dicomRS: ".format(pth_dicomRS))
 
-    pth_input = "../data_test/prostate-glen-p1-planFiles/ct.egsphant"
+    pth_input = "data_test/prostate-glen-p1-planFiles/ct.egsphant"
     # pth_output = os.path.dirname(pth_input) + "/test_"+os.path.basename(pth_input)
 
     egsphant_obj = BrachyEgsphant(pth_input)
@@ -32,9 +32,9 @@ def test_crop_by_dicom_structure():
 
 
 def test_crop_by_index():
-    pth_input = "../data_test/prostate-glen-p1-planFiles/ct.egsphant"
+    pth_input = "data_test/prostate-glen-p1-planFiles/ct.egsphant"
     pth_output = (
-        "../data_test/test_export_plan" + "/cropped" + os.path.basename(pth_input)
+        "data_test/test_export_plan" + "/cropped" + os.path.basename(pth_input)
     )
     egsphant_obj = BrachyEgsphant(pth_egsphant_file=pth_input)
     egsphant_obj.info()
@@ -46,9 +46,9 @@ def test_crop_by_index():
 
 
 def test_write_to_egsphant():
-    pth_input = "../data_test/prostate-glen-p1-planFiles/ct.egsphant"
+    pth_input = "data_test/prostate-glen-p1-planFiles/ct.egsphant"
     pth_output = (
-        "../data_test/test_export_plan" + "/test_" + os.path.basename(pth_input)
+        "data_test/test_export_plan" + "/test_" + os.path.basename(pth_input)
     )
 
     egsphant_obj = BrachyEgsphant(pth_egsphant_file=pth_input)
@@ -60,9 +60,9 @@ def test_write_to_egsphant():
 
 
 def test_write_to_nrrd():
-    egsphant_directory = "../data_test/prostate-glen-p1-planFiles/"
+    egsphant_directory = "data_test/prostate-glen-p1-planFiles/"
     pth_input = egsphant_directory + "ct.egsphant"
-    pth_export = "../data_test/test_export_plan/"
+    pth_export = "data_test/test_export_plan/"
     pth_output = pth_export + "ct.nrrd"
 
     egsphant_obj = BrachyEgsphant(pth_egsphant_file=pth_input)
@@ -86,7 +86,7 @@ def test_to_single_string():
 
 
 def test_load_from_ctegsphant():
-    pth_input = "../data_test/prostate-glen-p1-planFiles/ct.egsphant"
+    pth_input = "data_test/prostate-glen-p1-planFiles/ct.egsphant"
 
     egsphant_obj = BrachyEgsphant(pth_egsphant_file=pth_input)
     egsphant_obj.info()
@@ -102,16 +102,16 @@ def test_load_from_nrrd():
 
 
 def test_create_egsphant_from_images():
-    # dir_images = "../data_test/rectal-jgh-dcm"
-    dir_images = "../data_test/prostate-glen-p1-dcm"
+    # dir_images = "data_test/rectal-jgh-dcm"
+    dir_images = "data_test/prostate-glen-p1-dcm"
     # materials from CT
-    pth_materials = "../data_test/prostate-glen-p1-dcm/CTtoDensityProstate.txt"
-    pth_output = "../data_test/test_export_plan/test_ct.egsphant"
+    pth_materials = "data_test/prostate-glen-p1-dcm/CTtoDensityProstate.txt"
+    pth_output = "data_test/test_export_plan/test_ct.egsphant"
     load_structure = False
     assign_material_from_ct = True
     # # materials from contours
-    # pth_materials = "../data_test/prostate_material_dict.json"
-    # pth_output = "../data_test/test_export_plan/test_ct.egsphant"
+    # pth_materials = "data_test/prostate_material_dict.json"
+    # pth_output = "data_test/test_export_plan/test_ct.egsphant"
     # load_structure = True
     # assign_material_from_ct = False
     # dicom_obj = BrachyDicom(
@@ -146,9 +146,9 @@ def text_load_material_dict():
 
 
 def test_crop_by_coordinates():
-    pth_input = "../data_test/prostate-glen-p1-planFiles/ct.egsphant"
+    pth_input = "data_test/prostate-glen-p1-planFiles/ct.egsphant"
     pth_output = (
-        "../data_test/test_export_plan" + "/cropped" + os.path.basename(pth_input)
+        "data_test/test_export_plan" + "/cropped" + os.path.basename(pth_input)
     )
     egsphant_obj = BrachyEgsphant(pth_egsphant_file=pth_input)
     egsphant_obj.info()

--- a/brachyutils/tests/test_film_utils.py
+++ b/brachyutils/tests/test_film_utils.py
@@ -58,7 +58,7 @@ def test_create_devic_calibration_curve():
 
 
 def test_load_calibration_films():
-    test_calibration_films_path = "../../data_test/test_calibration_films/"
+    test_calibration_films_path = "data_test/test_calibration_films/"
     pixel_range = 65535.0  # 2^32 -1
     test_file_dict = dict()  # dict maps dose to array of file names
     test_file_dict[0] = ["0Gy062.tif", "0Gy063.tif"]

--- a/brachyutils/tests/test_geometry_utils.py
+++ b/brachyutils/tests/test_geometry_utils.py
@@ -174,12 +174,13 @@ def test_catheter_table():
 def test_catheter():
     from brachyutils.geometry.catheter_utils import Catheter, DwellPosition
     # # create a catheter from tip and last dwell position
-    # new_catheter = Catheter(
-        # index=0,
-        # tip_position=[25, 25, 25],
-        # last_dwell_coordinate=[0, 0, 0]
-    # )
-    # # create a catheter from digitization points
+    new_catheter = Catheter(
+        index=0,
+        tip_position=[25, 25, 25],
+        last_dwell_coordinate=[0, 0, 0]
+    )
+    print(new_catheter)
+    # create a catheter from digitization points
     coordinates_on_1_axis = np.arange(53, 1.5, -2)
     points = np.stack([
         coordinates_on_1_axis,

--- a/brachyutils/tests/test_geometry_utils.py
+++ b/brachyutils/tests/test_geometry_utils.py
@@ -189,6 +189,13 @@ def test_catheter():
     new_catheter = Catheter(index = 0, points=points)
     print(new_catheter)
 
+def test_catheter_to_mrk_json():
+    from brachyutils.geometry.catheter_utils import CatheterTable
+    pth_dicom = Path("data_test/prostate-glen-p1-dcm").resolve()
+    pth_out = "data_test/test_export_plan/prostate/test_catheter_table.mrk.json"
+    cat_table = CatheterTable(catheter_list=list(pth_dicom.glob("RP*.dcm"))[0])
+    cat_table.write_to_slicer_markup(pth_mrk_json=pth_out)
+
 def test_BrachyApplicator():
     pth_applicator_stl = "data_test/rectal-jgh-planFiles/applicator_0.stl"
     applicator_obj = BrachyApplicator(pth_applicator_stl)
@@ -345,7 +352,7 @@ if __name__ == "__main__":
     # test_crop_phantom()
     # print("testing CatheterTable")
     # test_catheter_table()
-    test_catheter()
+    # test_catheter()
     # print("testing BrachyApplicator")
     # test_BrachyApplicator()
     # test_BrachyApplicator_to_mac()
@@ -354,3 +361,4 @@ if __name__ == "__main__":
     # test_load_nifti_image_and_segmentation_file()
     # test_resample_to()
     # test_dicom_rt_tools()
+    test_catheter_to_mrk_json()

--- a/brachyutils/tests/test_geometry_utils.py
+++ b/brachyutils/tests/test_geometry_utils.py
@@ -173,12 +173,20 @@ def test_catheter_table():
 
 def test_catheter():
     from brachyutils.geometry.catheter_utils import Catheter, DwellPosition
-    new_catheter = Catheter(
-        index=0,
-        tip_position=[25, 25, 25],
-        last_dwell_coordinate=[0, 0, 0]
-    )
-    print(new_catheter.to_dict())
+    # # create a catheter from tip and last dwell position
+    # new_catheter = Catheter(
+        # index=0,
+        # tip_position=[25, 25, 25],
+        # last_dwell_coordinate=[0, 0, 0]
+    # )
+    # # create a catheter from digitization points
+    coordinates_on_1_axis = np.arange(53, 1.5, -2)
+    points = np.stack([
+        coordinates_on_1_axis,
+        coordinates_on_1_axis,
+        coordinates_on_1_axis], axis=-1)
+    new_catheter = Catheter(index = 0, points=points)
+    print(new_catheter)
 
 def test_BrachyApplicator():
     pth_applicator_stl = "data_test/rectal-jgh-planFiles/applicator_0.stl"

--- a/brachyutils/tests/test_geometry_utils.py
+++ b/brachyutils/tests/test_geometry_utils.py
@@ -171,12 +171,19 @@ def test_catheter_table():
     cat_tab_json = CatheterTable(catheter_list=pth_json)
     cat_tab_json.info()
 
+def test_catheter():
+    from brachyutils.geometry.catheter_utils import Catheter, DwellPosition
+    new_catheter = Catheter(
+        index=0,
+        tip_position=[25, 25, 25],
+        last_dwell_coordinate=[0, 0, 0]
+    )
+    print(new_catheter.to_dict())
 
 def test_BrachyApplicator():
     pth_applicator_stl = "data_test/rectal-jgh-planFiles/applicator_0.stl"
     applicator_obj = BrachyApplicator(pth_applicator_stl)
     applicator_obj.info()
-
 
 def test_BrachyApplicator_to_mac():
     pth_applicator_stl = "data_test/rectal-jgh-planFiles/applicator_0.stl"
@@ -328,7 +335,8 @@ if __name__ == "__main__":
     # test_load_egsphant()
     # test_crop_phantom()
     # print("testing CatheterTable")
-    test_catheter_table()
+    # test_catheter_table()
+    test_catheter()
     # print("testing BrachyApplicator")
     # test_BrachyApplicator()
     # test_BrachyApplicator_to_mac()

--- a/brachyutils/tests/test_geometry_utils.py
+++ b/brachyutils/tests/test_geometry_utils.py
@@ -7,8 +7,8 @@ from brachyutils import BrachyPhantom
 from brachyutils.geometry.applicator_utils import BrachyApplicator
 
 def test_brachy_phantom():
-    # pth_dicom = "../data_test/prostate-glen-p1-dcm"
-    pth_nrrd = "../data_test/prostate_glen_p1_ct.nrrd"
+    # pth_dicom = "data_test/prostate-glen-p1-dcm"
+    pth_nrrd = "data_test/prostate_glen_p1_ct.nrrd"
     # pth_structure = glob(pth_dicom + "/RS*.dcm")[0]
     phantom_obj = BrachyPhantom(
         # dir_dicom=pth_dicom,
@@ -19,17 +19,17 @@ def test_brachy_phantom():
 
 
 def test_get_structure_mask():
-    pth_dicom = "../data_test/prostate-glen-p1-dcm"
+    pth_dicom = "data_test/prostate-glen-p1-dcm"
     pth_structure = glob(pth_dicom + "/RS*.dcm")[0]
     phantom_obj = BrachyPhantom(dir_dicom=pth_dicom, pth_structures_file=pth_structure)
     print(phantom_obj.get_structure_mask(["ctv"], mask_type=np.ndarray))
 
 
 def test_write_image_to_dicom():
-    pth_dicom = "../data_test/prostate-glen-p1-dcm"
-    pth_nrrd = "../data_test/prostate_glen_p1_ct.nrrd"
+    pth_dicom = "data_test/prostate-glen-p1-dcm"
+    pth_nrrd = "data_test/prostate_glen_p1_ct.nrrd"
     pth_structure = glob(pth_dicom + "/RS*.dcm")[0]
-    pth_out = "../data_test/test_export_plan/prostate/test_p1_ct"
+    pth_out = "data_test/test_export_plan/prostate/test_p1_ct"
     phantom_obj = BrachyPhantom(
         dir_dicom=pth_dicom,
         # pth_phantom_file=pth_nrrd,
@@ -43,46 +43,46 @@ def test_write_image_to_dicom():
     new_phantom.is_equal(phantom_obj)
 
 def test_write_image_to_nrrd():
-    pth_dicom = "../data_test/prostate-glen-p1-dcm"
-    pth_out = "../data_test/test_export_plan/prostate/prostate_glen_p1_ct.nrrd"
+    pth_dicom = "data_test/prostate-glen-p1-dcm"
+    pth_out = "data_test/test_export_plan/prostate/prostate_glen_p1_ct.nrrd"
     phantom_obj = BrachyPhantom(dir_dicom=pth_dicom)
     phantom_obj.write_image_to_nrrd(pth_out)
     new_phantom = BrachyPhantom(pth_phantom_file=pth_out)
     assert (new_phantom.is_equal(phantom_obj)), "Test failed the two phantoms are not equal."
 
 def test_write_structures_to_nrrd():
-    pth_dicom = "../data_test/prostate-glen-p1-dcm"
+    pth_dicom = "data_test/prostate-glen-p1-dcm"
     pth_structure = glob(pth_dicom + "/RS*.dcm")[0]
-    pth_out = "../data_test/test_export_plan/prostate/prostate_glen_p1_structs.seg.nrrd"
+    pth_out = "data_test/test_export_plan/prostate/prostate_glen_p1_structs.seg.nrrd"
     phantom_obj = BrachyPhantom(dir_dicom=pth_dicom, pth_structures_file=pth_structure)
     phantom_obj.write_structures_to_nrrd(pth_out, overlap=False)
 
 
 def test_write_structures_to_dicom():
-    pth_dicom = "../data_test/prostate-glen-p1-dcm"
+    pth_dicom = "data_test/prostate-glen-p1-dcm"
     pth_structure = glob(pth_dicom + "/RS*.dcm")[0]
-    pth_out = "../data_test/test_export_plan/prostate/test_p1_dcm"
+    pth_out = "data_test/test_export_plan/prostate/test_p1_dcm"
     phantom_obj = BrachyPhantom(dir_dicom=pth_dicom, pth_structures_file=pth_structure)
     phantom_obj.write_image_to_dicom(pth_out)
     phantom_obj.write_structures_to_dicom(pth_out)
 
 
 def test_read_structures_from_nrrd():
-    pth_dicom = "../data_test/prostate-glen-p1-dcm"
-    pth_structures = "../data_test/test_export_plan/prostate/prostate_glen_p1_structs.seg.nrrd"
-    pth_out = "../data_test/test_export_plan/prostate/test_p1_dcm/rs.seg.nrrd"
+    pth_dicom = "data_test/prostate-glen-p1-dcm"
+    pth_structures = "data_test/test_export_plan/prostate/prostate_glen_p1_structs.seg.nrrd"
+    pth_out = "data_test/test_export_plan/prostate/test_p1_dcm/rs.seg.nrrd"
     phantom_obj = BrachyPhantom(dir_dicom=pth_dicom, pth_structures_file=pth_structures)
     print(phantom_obj.info())
     # phantom_obj.write_image_to_nrrd(pth_out)
     phantom_obj.write_structures_to_nrrd(pth_out, overlap=True)
 
 def test_write_to_egsphant():
-    pth_dicom = "../data_test/prostate-glen-p1-dcm"
+    pth_dicom = "data_test/prostate-glen-p1-dcm"
     pth_structure = glob(pth_dicom + "/RS*.dcm")[0]
-    pth_out = "../data_test/test_export_plan/prostate/test_ct.egsphant"
-    # pth_materials = "../data_test/prostate-glen-p1-dcm/CTtoDensityProstate.txt"
+    pth_out = "data_test/test_export_plan/prostate/test_ct.egsphant"
+    # pth_materials = "data_test/prostate-glen-p1-dcm/CTtoDensityProstate.txt"
     # assign_material_from_ct = True
-    pth_materials = "../data_test/prostate_material_dict.json"
+    pth_materials = "data_test/prostate_material_dict.json"
     assign_material_from_ct = False
 
     phantom_obj = BrachyPhantom(
@@ -97,8 +97,8 @@ def test_write_to_egsphant():
 
 
 def test_load_egsphant():
-    pth_egsphant = "../data_test/prostate-glen-p1-planFiles/ct.egsphant"
-    pth_out = "../data_test/test_export_plan/prostate/test_ct.egsphant"
+    pth_egsphant = "data_test/prostate-glen-p1-planFiles/ct.egsphant"
+    pth_out = "data_test/test_export_plan/prostate/test_ct.egsphant"
 
     phantom_obj = BrachyPhantom(pth_egsphant_file=pth_egsphant)
     phantom_obj.write_to_egsphant(
@@ -106,9 +106,9 @@ def test_load_egsphant():
     )
 
 def test_crop_phantom():
-    pth_dicom = "../data_test/prostate-glen-p1-dcm"
+    pth_dicom = "data_test/prostate-glen-p1-dcm"
     pth_structure = glob(pth_dicom + "/RS*.dcm")[0]
-    pth_out = "../data_test/test_export_plan"
+    pth_out = "data_test/test_export_plan"
     phantom_obj = BrachyPhantom(dir_dicom=pth_dicom, pth_structures_file=pth_structure)
     crop_coordinates = np.array([[-100, 100], [-150, 200], [-1280, -1140]])
     phantom_obj.crop_by_coordinates(crop_coordinates)
@@ -162,8 +162,8 @@ def test_catheter_table():
     # print(catheter_obj.to_dict())
 
     # # test loadin from dicom
-    pth_dicom = "../data_test/prostate-glen-p1-dcm"
-    pth_json = "../data_test/test_export_plan/prostate/test_catheter_table.json"
+    pth_dicom = "data_test/prostate-glen-p1-dcm"
+    pth_json = "data_test/test_export_plan/prostate/test_catheter_table.json"
     pth_plan = glob(pth_dicom + "/RP*.dcm")[0]
     catheter_table = CatheterTable(catheter_list=pth_plan)
     catheter_table.write_to_json(pth_json)
@@ -173,18 +173,18 @@ def test_catheter_table():
 
 
 def test_BrachyApplicator():
-    pth_applicator_stl = "../data_test/rectal-jgh-planFiles/applicator_0.stl"
+    pth_applicator_stl = "data_test/rectal-jgh-planFiles/applicator_0.stl"
     applicator_obj = BrachyApplicator(pth_applicator_stl)
     applicator_obj.info()
 
 
 def test_BrachyApplicator_to_mac():
-    pth_applicator_stl = "../data_test/rectal-jgh-planFiles/applicator_0.stl"
+    pth_applicator_stl = "data_test/rectal-jgh-planFiles/applicator_0.stl"
     origin = np.array([0, 0, 0])
     rotation = np.array([0, 0, 0])
     material = "Tungsten"
     density = 19.3
-    pth_outfile = "../data_test/test_export_plan/applicator_0.mac"
+    pth_outfile = "data_test/test_export_plan/applicator_0.mac"
     applicator_obj = BrachyApplicator(
         pth_input_file=pth_applicator_stl,
         material=material,
@@ -196,13 +196,13 @@ def test_BrachyApplicator_to_mac():
 
 
 def test_BrachyApplicator_to_stl():
-    pth_applicator_stl = "../data_test/rectal-jgh-planFiles/applicator_0.stl"
+    pth_applicator_stl = "data_test/rectal-jgh-planFiles/applicator_0.stl"
     origin = np.array([0, 0, 0])
     rotation = np.array([90, 1, 0, 0])
     coordinates = np.array([0, 0, 0])
     material = "Tungsten"
     density = 19.3
-    pth_outfile = "../data_test/test_export_plan/applicator_0_tilted.stl"
+    pth_outfile = "data_test/test_export_plan/applicator_0_tilted.stl"
     applicator_obj = BrachyApplicator(
         pth_input_file=pth_applicator_stl,
         material=material,
@@ -215,14 +215,14 @@ def test_BrachyApplicator_to_stl():
 
 
 def test_BrachyApplicator_set_rotation():
-    pth_applicator_stl = "../data_test/rectal-jgh-planFiles/applicator_0.stl"
+    pth_applicator_stl = "data_test/rectal-jgh-planFiles/applicator_0.stl"
     origin = np.array([0, 0, 0])
     coordinates = np.array([50, 50, 50])
     rotation = np.array([90, 0, 1, 0])
     rotation_origin = np.array([50, 50, 50])
     material = "Tungsten"
     density = 19.3
-    pth_outfile = "../data_test/test_export_plan/applicator_0_tilted.stl"
+    pth_outfile = "data_test/test_export_plan/applicator_0_tilted.stl"
     applicator_obj = BrachyApplicator(
         pth_input_file=pth_applicator_stl,
         material=material,
@@ -235,22 +235,22 @@ def test_BrachyApplicator_set_rotation():
 
 def test_load_nifti_image_and_segmentation_file():
     # CT images Abdomen
-    pth_img_nifti = Path("../data_test/registration/abdomin_mr_ct/tr_mr_image_0001.nii.gz")
-    pth_img_out = Path("../data_test/test_export_plan/abdomin_mr_ct/tr_mr_image_0001.nrrd")
-    pth_label_nifti = Path("../data_test/registration/abdomin_mr_ct/tr_mr_label_0001.nii.gz")
-    pth_label_out = Path("../data_test/test_export_plan/abdomin_mr_ct/tr_mr_label_0001.seg.nrrd")
+    pth_img_nifti = Path("data_test/registration/abdomin_mr_ct/tr_mr_image_0001.nii.gz")
+    pth_img_out = Path("data_test/test_export_plan/abdomin_mr_ct/tr_mr_image_0001.nrrd")
+    pth_label_nifti = Path("data_test/registration/abdomin_mr_ct/tr_mr_label_0001.nii.gz")
+    pth_label_out = Path("data_test/test_export_plan/abdomin_mr_ct/tr_mr_label_0001.seg.nrrd")
 
     # mri images prostate
-    # pth_img_nifti = Path("../data_test/registration_prostate_mr_us/train_mr_image_case000000.nii.gz")
-    # pth_img_out = Path("../data_test/test_export_plan/test_mr_image_case000000.nrrd")
-    # pth_label_nifti = Path("../data_test/registration_prostate_mr_us/train_mr_label_case000000.nii.gz")
-    # pth_label_out = Path("../data_test/test_export_plan/test_mr_label_case000000.seg.nrrd")
+    # pth_img_nifti = Path("data_test/registration_prostate_mr_us/train_mr_image_case000000.nii.gz")
+    # pth_img_out = Path("data_test/test_export_plan/test_mr_image_case000000.nrrd")
+    # pth_label_nifti = Path("data_test/registration_prostate_mr_us/train_mr_label_case000000.nii.gz")
+    # pth_label_out = Path("data_test/test_export_plan/test_mr_label_case000000.seg.nrrd")
     
     # ultrasound images
-    # pth_img_nifti = Path("../data_test/registration_prostate_mr_us/train_us_image_case000000.nii.gz")
-    # pth_img_out = Path("../data_test/test_export_plan/test_us_image_case000000.nrrd")
-    # pth_label_nifti = Path("../data_test/registration_prostate_mr_us/train_us_label_case000000.nii.gz")
-    # pth_label_out = Path("../data_test/test_export_plan/test_us_label_case000000.seg.nrrd")
+    # pth_img_nifti = Path("data_test/registration_prostate_mr_us/train_us_image_case000000.nii.gz")
+    # pth_img_out = Path("data_test/test_export_plan/test_us_image_case000000.nrrd")
+    # pth_label_nifti = Path("data_test/registration_prostate_mr_us/train_us_label_case000000.nii.gz")
+    # pth_label_out = Path("data_test/test_export_plan/test_us_label_case000000.seg.nrrd")
 
     phantom_obj = BrachyPhantom(
         pth_phantom_file=pth_img_nifti,
@@ -268,9 +268,9 @@ def test_resample_to():
         represented by opentps are not upsampled properly.
         Will attempt rttools here.
     """
-    pth_dicom = "../data_test/prostate-glen-p1-dcm"
+    pth_dicom = "data_test/prostate-glen-p1-dcm"
     pth_structures = glob(pth_dicom + "/RS*.dcm")[0]
-    pth_out = "../data_test/test_export_plan/prostate"
+    pth_out = "data_test/test_export_plan/prostate"
     
     origin = None
     spacing = np.array([1., 1., 1.])
@@ -284,9 +284,9 @@ def test_resample_to():
 
 def test_dicom_rt_tools():
 
-    pth_dicom = "../data_test/prostate-glen-p1-dcm"
+    pth_dicom = "data_test/prostate-glen-p1-dcm"
     pth_structures = glob(pth_dicom + "/RS*.dcm")[0]
-    pth_out = "../data_test/test_export_plan/prostate"
+    pth_out = "data_test/test_export_plan/prostate"
     5
     origin = None
     spacing = np.array([1., 1., 1.])

--- a/brachyutils/tests/test_plan_utils.py
+++ b/brachyutils/tests/test_plan_utils.py
@@ -9,7 +9,7 @@ from brachyutils.plan_utils import BrachyPlan, _load_single_dose_or_uncertainty_
 
 
 def test_extract_dwell_numbers_times_coordinates_from_catheterTable():
-    pth_cathTable_json = "../data_test/prostate-glen-p1-planFiles/catheter_table.json"
+    pth_cathTable_json = "data_test/prostate-glen-p1-planFiles/catheter_table.json"
 
     plan_obj = BrachyPlan(catheter_table=pth_cathTable_json)
 
@@ -23,7 +23,7 @@ def test_extract_dwell_numbers_times_coordinates_from_catheterTable():
 
 
 def test_update_catheter_table_from_plan():
-    pth_cathTable_json = "../data_test/prostate-glen-p1-planFiles/catheter_table.json"
+    pth_cathTable_json = "data_test/prostate-glen-p1-planFiles/catheter_table.json"
 
     plan_obj = BrachyPlan(catheter_table=pth_cathTable_json)
     plan_obj.catheter_table.info()
@@ -32,8 +32,8 @@ def test_update_catheter_table_from_plan():
 
 
 def test_load_dose_rate_or_uncertainty_tensor():
-    pth_cathTable_json = "../data_test/prostate-glen-p1-planFiles/catheter_table.json"
-    dir_dose_rate = "../data_test/prostate-glen-p1-dose"
+    pth_cathTable_json = "data_test/prostate-glen-p1-planFiles/catheter_table.json"
+    dir_dose_rate = "data_test/prostate-glen-p1-dose"
 
     plan_obj = BrachyPlan(
         catheter_table=pth_cathTable_json,
@@ -49,9 +49,9 @@ def test_load_dose_rate_or_uncertainty_tensor():
 
 
 def test_create_structures_and_calc_dvh_metrics():
-    dir_dicom = "../data_test/prostate-glen-p1-dcm"
-    pth_cathTable_json = "../data_test/prostate-glen-p1-planFiles/catheter_table.json"
-    # dir_dose_rate = "../data_test/prostate-glen-p1-dose"
+    dir_dicom = "data_test/prostate-glen-p1-dcm"
+    pth_cathTable_json = "data_test/prostate-glen-p1-planFiles/catheter_table.json"
+    # dir_dose_rate = "data_test/prostate-glen-p1-dose"
     pth_dose = glob(dir_dicom + "/RD*.dcm")[0]
     dvh_metric_goals = {
         "D95%(ctv)": 15,
@@ -72,8 +72,8 @@ def test_create_structures_and_calc_dvh_metrics():
 
 
 def test_calculate_combined_uncertainty():
-    pth_cathTable_json = "../data_test/prostate-glen-p1-planFiles/catheter_table.json"
-    dir_dose_rate = "../data_test/prostate-glen-p1-dose"
+    pth_cathTable_json = "data_test/prostate-glen-p1-planFiles/catheter_table.json"
+    dir_dose_rate = "data_test/prostate-glen-p1-dose"
 
     plan_obj = BrachyPlan(
         catheter_table=pth_cathTable_json,
@@ -92,10 +92,10 @@ def test_calculate_combined_uncertainty():
 
 def test_calculate_uncertainty_per_structure():
     pth_catheter_table_json = (
-        "../data_test/prostate-glen-p1-planFiles/catheter_table.json"
+        "data_test/prostate-glen-p1-planFiles/catheter_table.json"
     )
-    dir_dose_rate = "../data_test/prostate-glen-p1-dose/"
-    dir_dicom = "../data_test/prostate-glen-p1-dcm/"
+    dir_dose_rate = "data_test/prostate-glen-p1-dose/"
+    dir_dicom = "data_test/prostate-glen-p1-dcm/"
     dvh_metric_goals = {
         "D95%(ctv)": 15,
         "D1cc(rectum)": 11.25,
@@ -124,10 +124,10 @@ def test_calculate_uncertainty_per_structure():
 
 def test_BrachyPlan():
     pth_catheter_table_json = (
-        "../data_test/prostate-glen-p1-planFiles/catheter_table.json"
+        "data_test/prostate-glen-p1-planFiles/catheter_table.json"
     )
-    dir_dose_rate = "../data_test/prostate-glen-p1-dose/"
-    dir_dicom = "../data_test/prostate-glen-p1-dcm"
+    dir_dose_rate = "data_test/prostate-glen-p1-dose/"
+    dir_dicom = "data_test/prostate-glen-p1-dcm"
     dvh_metric_goals = {
         "D95%(ctv)": 15,
         "D1cc(rectum)": 11.25,
@@ -144,22 +144,22 @@ def test_BrachyPlan():
 
 
 def test__load_single_dose_or_uncertainty_to_dict():
-    pth_dose_rate = "../data_test/prostate-glen-p1-dose/scaled_run_1.nrrd"
+    pth_dose_rate = "data_test/prostate-glen-p1-dose/scaled_run_1.nrrd"
     dose_rate_dict = _load_single_dose_or_uncertainty_to_dict(pth_dose_rate, "both")
     print(dose_rate_dict[0].shape)  # dose
     print(dose_rate_dict[1].shape)  # uncertainty
 
 
 def test_export_brachy_plan():
-    pth_cathTable_json = "../data_test/prostate-glen-p1-planFiles/catheter_table.json"
-    dir_dose_rate = "../data_test/prostate-glen-p1-dose"
-    dir_dicom = "../data_test/prostate-glen-p1-dcm/"
+    pth_cathTable_json = "data_test/prostate-glen-p1-planFiles/catheter_table.json"
+    dir_dose_rate = "data_test/prostate-glen-p1-dose"
+    dir_dicom = "data_test/prostate-glen-p1-dcm/"
     pth_combined_dose = glob(dir_dicom + "/RD*.dcm")[0]
-    # dir_egsphant = "../data_test/prostate-glen-p1-planFiles/ct.egsphant"
+    # dir_egsphant = "data_test/prostate-glen-p1-planFiles/ct.egsphant"
     # assign material based on contours:
-    pth_material = "../data_test/prostate_material_dict.json"
+    pth_material = "data_test/prostate_material_dict.json"
     # assign materials based on CT values:
-    # pth_material = "../data_test/CTtoDensityProstate.txt"
+    # pth_material = "data_test/CTtoDensityProstate.txt"
     dvh_metric_goals = {
         "D95%(ctv)": 15,
         "D1cc(rectum)": 11.25,
@@ -181,7 +181,7 @@ def test_export_brachy_plan():
         "PrintProgress": 10000,
         "beam_on": 10000,
     }
-    dir_export = "../data_test/test_export_plan"
+    dir_export = "data_test/test_export_plan"
     export_format = "RapidBrachy"
     os.makedirs(dir_export, exist_ok=True)
 
@@ -213,7 +213,7 @@ def test_export_brachy_plan():
 
 
 def test_load_brachy_plan_from_dicom():
-    pth_dicom = "../data_test/prostate-glen-p1-dcm/"
+    pth_dicom = "data_test/prostate-glen-p1-dcm/"
     dvh_metric_goals = {
         "D95%(ctv)": 15,
         "D1cc(rectum)": 11.25,
@@ -223,8 +223,8 @@ def test_load_brachy_plan_from_dicom():
     plan_obj.info()
 
 def test_load_applicator_list():
-    dir_dicom = "../data_test/rectal-jgh-dcm"
-    dir_plan = "../data_test/rectal-jgh-planFiles"
+    dir_dicom = "data_test/rectal-jgh-dcm"
+    dir_plan = "data_test/rectal-jgh-planFiles"
     pth_applicator_geometry = os.path.join(dir_plan, "applicator_geometry.json")
 
     plan_obj = BrachyPlan(
@@ -236,10 +236,10 @@ def test_load_applicator_list():
 
 
 def test__export_applicator_geometry():
-    dir_dicom = "../data_test/rectal-jgh-dcm"
-    dir_plan = "../data_test/rectal-jgh-planFiles"
+    dir_dicom = "data_test/rectal-jgh-dcm"
+    dir_plan = "data_test/rectal-jgh-planFiles"
     pth_applicator_geometry = os.path.join(dir_plan, "applicator_geometry.json")
-    dir_export = "../data_test/test_export_plan"
+    dir_export = "data_test/test_export_plan"
     plan_obj = BrachyPlan(
         phantom=dir_dicom,
         applicator=pth_applicator_geometry,
@@ -256,7 +256,7 @@ def test_brachy_structure():
 
     from brachyutils import BrachyDose, BrachyPhantom, BrachyStructure
 
-    pth_dicom = "../data_test/prostate-glen-p1-dcm/"
+    pth_dicom = "data_test/prostate-glen-p1-dcm/"
     pth_structure = glob(pth_dicom + "/RS*.dcm")[0]
     pth_dose = glob(pth_dicom + "/RD*.dcm")[0]
     structure_name = "CTV"
@@ -284,7 +284,7 @@ def test_brachy_structure():
 def test_load_phantom():
     from pathlib import Path
 
-    pth_dicom = Path("../data_test/prostate-glen-p1-dcm/")
+    pth_dicom = Path("data_test/prostate-glen-p1-dcm/")
 
     dvh_metric_goals = {
         "D95%(ctv)": 15,

--- a/brachyutils/tests/test_registration_utils.py
+++ b/brachyutils/tests/test_registration_utils.py
@@ -4,29 +4,29 @@ from brachyutils.geometry_utils import BrachyPhantom
 
 def test_register_opentps():
     # Abdominal: static = CT, moving = MR
-    pth_img_static = Path("../temp_data/registration/abdomen-mr-ct/static/AbdomenMRCT_0001.nrrd")
-    # pth_img_static = Path("../data_test/registration/abdomin_mr_ct/tr_ct_image_0001.nii.gz")
-    pth_label_static = Path("../temp_data/registration/abdomen-mr-ct/static/AbdomenMRCT_0001.seg.nrrd")
-    # pth_label_static = Path("../data_test/registration/abdomin_mr_ct/tr_ct_label_0001.nii.gz")
-    pth_img_moving = Path("../temp_data/registration/abdomen-mr-ct/moving/AbdomenMRCT_0001.nrrd")
-    # pth_img_moving = Path("../data_test/registration/abdomin_mr_ct/tr_mr_image_0001.nii.gz")
-    pth_label_moving = Path("../temp_data/registration/abdomen-mr-ct/moving/AbdomenMRCT_0001.seg.nrrd")
-    # pth_label_moving = Path("../data_test/registration/abdomin_mr_ct/tr_mr_label_0001.nii.gz")
-    pth_output = Path("../data_test/test_export_plan/abdomin_mr_ct/registered_abdomin_ct_mr.nrrd")
+    pth_img_static = Path("temp_data/registration/abdomen-mr-ct/static/AbdomenMRCT_0001.nrrd")
+    # pth_img_static = Path("data_test/registration/abdomin_mr_ct/tr_ct_image_0001.nii.gz")
+    pth_label_static = Path("temp_data/registration/abdomen-mr-ct/static/AbdomenMRCT_0001.seg.nrrd")
+    # pth_label_static = Path("data_test/registration/abdomin_mr_ct/tr_ct_label_0001.nii.gz")
+    pth_img_moving = Path("temp_data/registration/abdomen-mr-ct/moving/AbdomenMRCT_0001.nrrd")
+    # pth_img_moving = Path("data_test/registration/abdomin_mr_ct/tr_mr_image_0001.nii.gz")
+    pth_label_moving = Path("temp_data/registration/abdomen-mr-ct/moving/AbdomenMRCT_0001.seg.nrrd")
+    # pth_label_moving = Path("data_test/registration/abdomin_mr_ct/tr_mr_label_0001.nii.gz")
+    pth_output = Path("data_test/test_export_plan/abdomin_mr_ct/registered_abdomin_ct_mr.nrrd")
 
     # # prostate: static = US, moving = MR
-    # pth_img_static = Path("../data_test/registration/prostate_mr_us/train_us_image_case000000.nii.gz")
-    # pth_img_moving = Path("../data_test/registration/prostate_mr_us/train_mr_image_case000000.nii.gz")
-    # pth_label_static = Path("../data_test/registration/prostate_mr_us/train_us_label_case000000.nii.gz")
-    # pth_label_moving = Path("../data_test/registration/prostate_mr_us/train_mr_label_case000000.nii.gz")
-    # pth_output = Path("../data_test/test_export_plan/prostate/registered_phantom_us_mr.nrrd")
+    # pth_img_static = Path("data_test/registration/prostate_mr_us/train_us_image_case000000.nii.gz")
+    # pth_img_moving = Path("data_test/registration/prostate_mr_us/train_mr_image_case000000.nii.gz")
+    # pth_label_static = Path("data_test/registration/prostate_mr_us/train_us_label_case000000.nii.gz")
+    # pth_label_moving = Path("data_test/registration/prostate_mr_us/train_mr_label_case000000.nii.gz")
+    # pth_output = Path("data_test/test_export_plan/prostate/registered_phantom_us_mr.nrrd")
 
     # prostate: static = MR, moving = US 
-    # pth_img_static = Path("../data_test/registration/prostate_mr_us/train_mr_image_case000000.nii.gz")    
-    # pth_img_moving = Path("../data_test/registration/prostate_mr_us/train_us_image_case000000.nii.gz")
-    # pth_label_static = Path("../data_test/registration/prostate_mr_us/train_mr_label_case000000.nii.gz")
-    # pth_label_moving = Path("../data_test/registration/prostate_mr_us/train_us_label_case000000.nii.gz")
-    # pth_output = Path("../data_test/test_export_plan/prostate/registered_phantom_us_mr.nrrd")
+    # pth_img_static = Path("data_test/registration/prostate_mr_us/train_mr_image_case000000.nii.gz")    
+    # pth_img_moving = Path("data_test/registration/prostate_mr_us/train_us_image_case000000.nii.gz")
+    # pth_label_static = Path("data_test/registration/prostate_mr_us/train_mr_label_case000000.nii.gz")
+    # pth_label_moving = Path("data_test/registration/prostate_mr_us/train_us_label_case000000.nii.gz")
+    # pth_output = Path("data_test/test_export_plan/prostate/registered_phantom_us_mr.nrrd")
     for pth in [pth_img_static, pth_img_moving, pth_label_static, pth_label_moving]:
         assert pth.exists(), f"File {pth} does not exist."
 
@@ -69,15 +69,15 @@ def test_register_opentps():
 def test_register_plastimatch():
     from brachyutils.registration_utils import Registration_Plastimatch
     # Abdominal: static = CT, moving = MR
-    pth_img_static = Path("../temp_data/registration/abdomen-mr-ct/static/AbdomenMRCT_0008.nrrd")
-    # pth_img_static = Path("../data_test/registration/abdomin_mr_ct/tr_ct_image_0008.nii.gz")
-    pth_label_static = Path("../temp_data/registration/abdomen-mr-ct/static/AbdomenMRCT_0008.seg.nrrd")
-    # pth_label_static = Path("../data_test/registration/abdomin_mr_ct/tr_ct_label_0008.nii.gz")
-    pth_img_moving = Path("../temp_data/registration/abdomen-mr-ct/moving/AbdomenMRCT_0008.nrrd")
-    # pth_img_moving = Path("../data_test/registration/abdomin_mr_ct/tr_mr_image_0008.nii.gz")
-    pth_label_moving = Path("../temp_data/registration/abdomen-mr-ct/moving/AbdomenMRCT_0008.seg.nrrd")
-    # pth_label_moving = Path("../data_test/registration/abdomin_mr_ct/tr_mr_label_0001.nii.gz")
-    pth_output = Path("../temp_data/registration/abdomen-mr-ct/test")
+    pth_img_static = Path("temp_data/registration/abdomen-mr-ct/static/AbdomenMRCT_0008.nrrd")
+    # pth_img_static = Path("data_test/registration/abdomin_mr_ct/tr_ct_image_0008.nii.gz")
+    pth_label_static = Path("temp_data/registration/abdomen-mr-ct/static/AbdomenMRCT_0008.seg.nrrd")
+    # pth_label_static = Path("data_test/registration/abdomin_mr_ct/tr_ct_label_0008.nii.gz")
+    pth_img_moving = Path("temp_data/registration/abdomen-mr-ct/moving/AbdomenMRCT_0008.nrrd")
+    # pth_img_moving = Path("data_test/registration/abdomin_mr_ct/tr_mr_image_0008.nii.gz")
+    pth_label_moving = Path("temp_data/registration/abdomen-mr-ct/moving/AbdomenMRCT_0008.seg.nrrd")
+    # pth_label_moving = Path("data_test/registration/abdomin_mr_ct/tr_mr_label_0001.nii.gz")
+    pth_output = Path("temp_data/registration/abdomen-mr-ct/test")
 
     for pth in [pth_img_static, pth_img_moving, pth_label_static, pth_label_moving]:
         assert pth.exists(), f"File {pth} does not exist."
@@ -100,9 +100,9 @@ def test_register_plastimatch():
     registration_obj.register(pth_phantom_export=pth_output)
 
 def test_load_transformations():
-    pth_transform = Path("../data_test/registration/abdomin_mr_ct/plastimatch/vf.nrrd")
-    pth_moving_img = Path("../data_test/registration/abdomin_mr_ct/plastimatch/moving.nrrd")
-    pth_output = Path("../data_test/test_export_plan/abdomin_mr_ct/vf_transformed_image.nrrd")
+    pth_transform = Path("data_test/registration/abdomin_mr_ct/plastimatch/vf.nrrd")
+    pth_moving_img = Path("data_test/registration/abdomin_mr_ct/plastimatch/moving.nrrd")
+    pth_output = Path("data_test/test_export_plan/abdomin_mr_ct/vf_transformed_image.nrrd")
     assert pth_transform.exists(), f"File {pth_transform} does not exist."
     from brachyutils.registration_utils import _load_deformation_field
 

--- a/docker_src/command_docker.sh
+++ b/docker_src/command_docker.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+xhost +local: # to allow the container to access the host display
 # to build the image and run the container
 # docker compose up --build -d BrachyUtils
 # to run the container without building the image

--- a/docker_src/docker-compose.yaml
+++ b/docker_src/docker-compose.yaml
@@ -17,9 +17,11 @@ services:
       - GID=${GID}
       - DEBIAN_FRONTEND=noninteractive
       - QT_QPA_PLATFORM=offscreen
+      - DISPLAY=${DISPLAY} # for access to graphical server
     volumes:
       - ${HOST_HOME}/Software/brachyutils:/root/Software/brachyutils
       - ${HOST_HOME}:/root/YourLocalHome
+      - /tmp/.X11-unix:/tmp/.X11-unix # for access to graphical server
     expose:
       - "8000"
     networks:

--- a/examples/benchmarks/eval_dose_generation.py
+++ b/examples/benchmarks/eval_dose_generation.py
@@ -60,7 +60,7 @@ def export_single_dicom_to_plan(
 def run_export():
     from functools import partial
     dir_all_dicoms = Path("/root/YourLocalHome/Data/prostate-glen-2023")
-    dir_export = Path("../temp_data/tg43/prostate-glen-2023")
+    dir_export = Path("temp_data/tg43/prostate-glen-2023")
     # pth_material = Path("../admin/constants/CTtoDensityProstate.txt")
     # mat_from_ct = True
     pth_material = Path("../admin/constants/structure_materials_prostate.json")
@@ -108,7 +108,7 @@ def run_export():
 
 def run_dose_generation():
     # # for TG43
-    dir_plan_export = Path("../temp_data/tg43/prostate-glen-2023")
+    dir_plan_export = Path("temp_data/tg43/prostate-glen-2023")
     list_plans = list(dir_plan_export.glob("*/"))
     run_multi_proc(run_single_tg43_dose_generation, list_plans, max_workers=8)    
 
@@ -236,7 +236,7 @@ def run_get_dvh_metrics_all_plans():
     # dir_all_plans = Path("/root/YourLocalHome/Data/prostate/plans-1mm/prostate-glen-2023")
     # # on photon
     pth_all_dicom = Path("/root/YourLocalHome/Data/prostate-glen-2023")
-    dir_all_plans = Path("../temp_data/tg43/prostate-glen-2023")
+    dir_all_plans = Path("temp_data/tg43/prostate-glen-2023")
     dvh_metric_goals = {
         "D95%(ctv)": 15,
         "D1cc(rectum)": 11.25,
@@ -251,7 +251,7 @@ def run_get_dvh_metrics_all_plans():
 def test_get_dvh_metrics_single_plan():
     pth_single_dicom = Path("/root/YourLocalHome/Data/prostate-glen-2023/p2")
     # dir_export = Path("/root/YourLocalHome/Data/prostate/plans-1mm/prostate-glen-2023/p1")
-    dir_export = Path("../temp_data/tg43/prostate-glen-2023/p2")
+    dir_export = Path("temp_data/tg43/prostate-glen-2023/p2")
     dvh_metric_goals = {
         "D95%(ctv)": 21,
         "D1cc(rectum)": 21*0.75,
@@ -266,7 +266,7 @@ def test_get_dvh_metrics_single_plan():
 
 def test_export():
     pth_single_dicom = Path("/root/YourLocalHome/Data/prostate/prostate-glen-2023/p1")
-    dir_export = Path("../temp_data/tg43/prostate-glen-2023")
+    dir_export = Path("temp_data/tg43/prostate-glen-2023")
     # pth_material = Path("../admin/constants/CTtoDensityProstate.txt")
     # mat_from_ct = True
     pth_material = Path("../admin/constants/structure_materials_prostate.json")
@@ -308,7 +308,7 @@ def test_export():
 
 def test_dose_calc():
     # # for monte carlo
-    dir_plan_export = Path("../temp_data/mc/prostate-glen-2023/p3")
+    dir_plan_export = Path("temp_data/mc/prostate-glen-2023/p3")
     pth_dose_executable = "http://192.168.1.11:8000/calculate_dose_mc"
     dose_gen_obj = DoseMonteCarlo(
         dir_plan_export=dir_plan_export,
@@ -318,7 +318,7 @@ def test_dose_calc():
     
     
     # # for tg43
-    dir_plan_export = Path("../temp_data/tg43/prostate-glen-2023/p1")
+    dir_plan_export = Path("temp_data/tg43/prostate-glen-2023/p1")
     pth_dose_executable = "http://192.168.1.12:8000/calculate_dose_tg43"
     dose_gen_obj = DoseTG43(
         dir_plan_export=dir_plan_export,
@@ -365,7 +365,7 @@ def scale_by_airkerma(dir_all_plans: str | Path, dir_all_dcms: str | Path):
         )
 
 def run_scale_by_airkerma():
-    dir_all_plans = Path("../temp_data/mc/prostate-glen-2023")
+    dir_all_plans = Path("temp_data/mc/prostate-glen-2023")
     dir_all_dcms = Path("/root/YourLocalHome/Data/prostate-glen-2023")
     scale_by_airkerma(dir_all_plans, dir_all_dcms)
 

--- a/examples/benchmarks/eval_registration.py
+++ b/examples/benchmarks/eval_registration.py
@@ -11,12 +11,12 @@ from brachyutils.geometry_utils import BrachyPhantom
 
 # def export_phantom_opentps_nrrd_dicom_egsphant():
 #     from brachyutils.geometry_utils import BrachyPhantom
-#     pth_img_dicom = Path("../data_test/prostate-glen-p1-dcm")
+#     pth_img_dicom = Path("data_test/prostate-glen-p1-dcm")
 #     pth_strct_dicom = glob(str(pth_img_dicom)+"/RS*.dcm")[0]
-#     pth_img_nrrd = Path("../data_test/test_export_plan/opentps/prostate_glen_p1.nrrd")
-#     pth_strct_nrrd = Path("../data_test/test_export_plan/opentps/prostate_glen_p1.seg.nrrd")
+#     pth_img_nrrd = Path("data_test/test_export_plan/opentps/prostate_glen_p1.nrrd")
+#     pth_strct_nrrd = Path("data_test/test_export_plan/opentps/prostate_glen_p1.seg.nrrd")
 #     assign_material_from_ct = True
-#     pth_materials = Path("../data_test/prostate-glen-p1-dcm/CTtoDensityProstate.txt")
+#     pth_materials = Path("data_test/prostate-glen-p1-dcm/CTtoDensityProstate.txt")
 #     phantom = BrachyPhantom(
 #         dir_dicom=pth_img_dicom,
 #         pth_structures_file=pth_strct_dicom
@@ -192,17 +192,17 @@ def eval_single_registration(
 
 def run_registeration_opentps():
     # # on abdomen MR-CT
-    dir_static = "../temp_data/registration/abdomen-mr-ct/static"
-    dir_moving = "../temp_data/registration/abdomen-mr-ct/moving"
+    dir_static = "temp_data/registration/abdomen-mr-ct/static"
+    dir_moving = "temp_data/registration/abdomen-mr-ct/moving"
     backend = "OpenTPS"
     use_contour = "" # None
-    dir_registered_quick = f"../temp_data/registration/abdomen-mr-ct/{backend}/{use_contour}/reg-quick"
-    dir_registered_demons = f"../temp_data/registration/abdomen-mr-ct/{backend}/{use_contour}/reg-demons"
-    dir_registered_morphons = f"../temp_data/registration/abdomen-mr-ct/{backend}/{use_contour}/reg-morphons"
+    dir_registered_quick = f"temp_data/registration/abdomen-mr-ct/{backend}/{use_contour}/reg-quick"
+    dir_registered_demons = f"temp_data/registration/abdomen-mr-ct/{backend}/{use_contour}/reg-demons"
+    dir_registered_morphons = f"temp_data/registration/abdomen-mr-ct/{backend}/{use_contour}/reg-morphons"
     # # on micro-reg prostate
-    # dir_static = "../temp_data/registration/micro-reg/us-train"
-    # dir_moving = "../temp_data/registration/micro-reg/mr-train"
-    # dir_registered = "../temp_data/registration/micro-reg/reg-train"
+    # dir_static = "temp_data/registration/micro-reg/us-train"
+    # dir_moving = "temp_data/registration/micro-reg/mr-train"
+    # dir_registered = "temp_data/registration/micro-reg/reg-train"
 
     from brachyutils.registration_utils import Registration_OpenTPS
     # # image based registration
@@ -246,11 +246,11 @@ def run_registration_plastimatch():
     from brachyutils.registration_utils import Registration_Plastimatch
 
     # # on abdomen MR-CT
-    dir_static = "../temp_data/registration/abdomen-mr-ct/static"
-    dir_moving = "../temp_data/registration/abdomen-mr-ct/moving"
+    dir_static = "temp_data/registration/abdomen-mr-ct/static"
+    dir_moving = "temp_data/registration/abdomen-mr-ct/moving"
     backend = "Plastimatch"
     use_contour = ""
-    dir_registered_bspline = f"../temp_data/registration/abdomen-mr-ct/{backend}/{use_contour}/reg-bspline"
+    dir_registered_bspline = f"temp_data/registration/abdomen-mr-ct/{backend}/{use_contour}/reg-bspline"
     pth_plastimatch = "http://192.168.1.13:8000"
 
     evaluate_registration(
@@ -351,6 +351,6 @@ def export_static_moving_phantoms(case: Dict, dir_static: Path, dir_moving: Path
     moving_phantom.export_to(dir_nrrd_out=dir_moving)
 
 if __name__ == "__main__": 
-    # organize_data("../temp_data/registration/abdomen-mr-ct", True)
+    # organize_data("temp_data/registration/abdomen-mr-ct", True)
     # run_registeration_opentps()
     run_registration_plastimatch()

--- a/examples/benchmarks/fix_prostate_trus_mr_data.py
+++ b/examples/benchmarks/fix_prostate_trus_mr_data.py
@@ -64,9 +64,9 @@ def fix_one_image_structure(
     phantom_obj.export_to(dir_nrrd_out=pth_output)
 
 def test_fix_one_image_structure():
-    pth_sample_image = Path("../data_test/registration/prostate_mr_us/train_mr_image_case000000.nii.gz")
-    pth_out = Path("../data_test/test_export_plan/prostate/corrected_mr_image.nrrd")
-    pth_sample_structure = Path("../data_test/registration/prostate_mr_us/train_mr_label_case000000.nii.gz")
+    pth_sample_image = Path("data_test/registration/prostate_mr_us/train_mr_image_case000000.nii.gz")
+    pth_out = Path("data_test/test_export_plan/prostate/corrected_mr_image.nrrd")
+    pth_sample_structure = Path("data_test/registration/prostate_mr_us/train_mr_label_case000000.nii.gz")
 
     fix_one_image_structure(pth_sample_image, pth_sample_structure, pth_out)
 
@@ -107,7 +107,7 @@ def fix_all_prostate_images(dir_img, dir_structure, dir_out, multi_thread: bool 
             return
 
 def test_read_nrrd():
-    dir_nrrd = Path("../data_test/test_export_plan/prostate")
+    dir_nrrd = Path("data_test/test_export_plan/prostate")
     all_nrrd = glob(str(dir_nrrd.joinpath("*.nrrd")))
     for pth in all_nrrd:
         if pth.endswith(".seg.nrrd"):
@@ -125,11 +125,11 @@ if __name__ == "__main__":
     # # fix the mr images and structures for the prostate
     # dir_img = Path("/root/YourLocalHome/Data/registration/prostate_us_mri/train/mr_images")
     # dir_structure = Path("/root/YourLocalHome/Data/registration/prostate_us_mri/train/mr_labels")
-    # dir_out = Path("../temp_data/registration/micro-reg/mr-train")
+    # dir_out = Path("temp_data/registration/micro-reg/mr-train")
     # fix_all_prostate_images(dir_img, dir_structure, dir_out, False)
 
     # # fix the ultrasound images and structures for the prostate
     # dir_img = Path("/root/YourLocalHome/Data/registration/prostate_us_mri/train/us_images")
     # dir_structure = Path("/root/YourLocalHome/Data/registration/prostate_us_mri/train/us_labels")
-    # dir_out = Path("../temp_data/registration/micro-reg/us-train")
+    # dir_out = Path("temp_data/registration/micro-reg/us-train")
     # fix_all_prostate_images(dir_img, dir_structure, dir_out, True)

--- a/examples/minimal_sim.py
+++ b/examples/minimal_sim.py
@@ -14,7 +14,7 @@ def export_plan_air_phantom():
                 dwells=[
                     DwellPosition(
                         index=0,
-                        position=[0.0, 0.0, 0.0],
+                        position=[50, 50, 50],
                         relativePos=0,
                         rotation=[0.0, 0.0, 0.0],
                         time=1.0,
@@ -24,7 +24,7 @@ def export_plan_air_phantom():
     )
     sim_dict = {
         "source_dict": {
-            "treatment_type": "LDR",
+            "treatment_type": "TLDR",
             "source_geometry": "IsoAid_Advantage",
             "core_material": "G4_Pd",
             "mass_number": "103",

--- a/examples/minimal_sim.py
+++ b/examples/minimal_sim.py
@@ -1,14 +1,60 @@
-from brachyutils import get_uniform_phantom, BrachyPlan
-
+from brachyutils import (
+    get_uniform_phantom, BrachyPlan,
+    CatheterTable, Catheter, DwellPosition
+)
 def export_plan_air_phantom():
     """
     Create a minimal simulation of a brachytherapy plan with an air phantom.
     """
+    dir_export = "temp_data/mc/test_Pd103"
+    catheterTable = CatheterTable(
+        catheter_list=[
+            Catheter(
+                index=0,
+                dwells=[
+                    DwellPosition(
+                        index=0,
+                        position=[0.0, 0.0, 0.0],
+                        relativePos=0,
+                        rotation=[0.0, 0.0, 0.0],
+                        time=1.0,
+                    )]
+                )
+            ]
+    )
+    sim_dict = {
+        "source_dict": {
+            "treatment_type": "LDR",
+            "source_geometry": "IsoAid_Advantage",
+            "core_material": "G4_Pd",
+            "mass_number": "103",
+            "atomic_number": "46",
+            "air_kerma_per_history": 1.149000e-11,
+            "reference_air_kerma": 5e04,
+        },
+        "pth_plan": "combined.plan",
+        "pth_phantom": "ct.egsphant",
+        "number_histories": 10000,
+        "total_time": 1,
+        "number_of_threads": 10,
+        "PrintProgress": 1000,
+    }
+    content_to_export = {
+        "egsphant": True,
+        "plan": True,
+        "mac": True,
+        "ApplicatorMaterials": False,
+        "applicator_geometry": False,
+    }
     # Create a minimal simulation of a brachytherapy plan with an air phantom
     air_phantom = get_uniform_phantom(voxel_value=-1000)
     # Export the plan to a JSON file
-    plan = BrachyPlan(phantom=air_phantom)
-    plan.export_to_json("minimal_brachy_plan.json")
+    plan = BrachyPlan(
+        phantom=air_phantom,
+        simulation_dict=sim_dict,
+        catheter_table=catheterTable
+        )
+    plan.export_brachy_plan(dir_export=dir_export, content_to_export=content_to_export)
     print("Brachytherapy plan exported to minimal_brachy_plan.json")
 
 if __name__ == "__main__":

--- a/examples/minimal_sim.py
+++ b/examples/minimal_sim.py
@@ -1,0 +1,15 @@
+from brachyutils import get_uniform_phantom, BrachyPlan
+
+def export_plan_air_phantom():
+    """
+    Create a minimal simulation of a brachytherapy plan with an air phantom.
+    """
+    # Create a minimal simulation of a brachytherapy plan with an air phantom
+    air_phantom = get_uniform_phantom(voxel_value=-1000)
+    # Export the plan to a JSON file
+    plan = BrachyPlan(phantom=air_phantom)
+    plan.export_to_json("minimal_brachy_plan.json")
+    print("Brachytherapy plan exported to minimal_brachy_plan.json")
+
+if __name__ == "__main__":
+    export_plan_air_phantom()


### PR DESCRIPTION
1. A few bug fixes to catheter table creation scenarios.
2. we can make empty phantoms out of thin air or any other materials and use them for planning.
3. the X11 server is passed to the docker file -> can visualize GUIs
4. writing catheter digitization points to .mrk.json for slicer to visualize (thanks to ai_assisted_brachy)
5. fixed the file path such that all the tests could be run from the 0 level directory on the repository.
