### PR TITLE
Hotspots

### DIFF
--- a/brachyutils/planning/optim_utils.py
+++ b/brachyutils/planning/optim_utils.py
@@ -322,7 +322,8 @@ class DwellTimeOptimizer(BaseModel):
             uniformity_weight = structure.optimization_config.penalty_weight_uniformity
             min_dose = structure.optimization_config.min_dose
             structure_max_dose = structure.optimization_config.max_dose
-
+            hotspot_threshold = structure.optimization_config.hotspot_threshold
+            hotspot_weight = structure.optimization_config.penalty_weight_hotspot
             # Build dose rate matrix and dwell time vector for this structure
             dose_rate_matrices = []
             dwell_vars = []
@@ -353,12 +354,13 @@ class DwellTimeOptimizer(BaseModel):
             # Stack dose rate matrices to create A matrix
             A = np.column_stack(dose_rate_matrices)  # Shape: (num_dose_points, num_variables)
             num_dose_points = A.shape[0]
-
             if num_dose_points == 0:
                 continue
-    
-            # Calculate dose vector: dose = A @ dwell_times
-            # This replaces the inner loop over dose points
+            # Convert A to sparse matrix
+            A_sparse = sp.csr_matrix(A)
+            # Create target dose vector
+            target_dose_vec = np.full(num_dose_points, target_dose)
+
             if structure.target_volume:
                 # Target volume constraints and penalties
                 # Create slack variables for underdosing
@@ -376,12 +378,7 @@ class DwellTimeOptimizer(BaseModel):
                     ub=target_dose - min_dose,
                     name=f"uniform_slack_{structure.name}"
                 )
-
-                # Convert A to sparse matrix for efficiency
-                A_sparse = sp.csr_matrix(A)
-
                 # Dose constraints: A @ dwell_times + x_slack >= target_dose
-                target_dose_vec = np.full(num_dose_points, target_dose)
                 model.addConstr(
                     A_sparse @ t_MVar + x_slack >= target_dose_vec,
                     name=f"dose_target_{structure.name}"
@@ -389,7 +386,7 @@ class DwellTimeOptimizer(BaseModel):
 
                 # Uniformity constraints: A @ dwell_times + y_uniform == target_dose
                 model.addConstr(
-                    A_sparse @ t_MVar + y_uniform == target_dose_vec,# - y_uniform,
+                    A_sparse @ t_MVar + y_uniform == target_dose_vec,
                     name=f"dose_uniform_{structure.name}"
                 )
 
@@ -405,9 +402,23 @@ class DwellTimeOptimizer(BaseModel):
                 # Uniformity penalty: sum(uniformity_weight_vec * y_uniform * y_uniform)
                 penalty_terms["uniformity"] += uniformity_weight_vec @ (y_uniform * y_uniform)
 
+            elif "hotspot_estimator:" in structure.name.lower():
+                # slack variable for hotspot estimator
+                x_slack = model.addMVar(
+                    shape=num_dose_points,
+                    lb=0.0,
+                    ub=hotspot_threshold * target_dose - min_dose,
+                    name=f"hotspot_slack_{structure.name}"
+                )
+                # Hotspot estimator constraints
+                model.addConstr(
+                    A_sparse @ t_MVar - x_slack <= hotspot_threshold * target_dose_vec,
+                )
+                hotspot_weight_vec = np.full(num_dose_points, hotspot_weight / num_dose_points)
+                penalty_terms["hotspot"] += (hotspot_weight_vec @ x_slack)
+
             else:
                 # OAR (Organ at Risk) constraints and penalties
-
                 # Create slack variables for overdosing
                 x_slack = model.addMVar(
                     shape=num_dose_points,
@@ -415,12 +426,7 @@ class DwellTimeOptimizer(BaseModel):
                     ub=structure_max_dose - target_dose,
                     name=f"oar_slack_{structure.name}"
                 )
-
-                # Convert A to sparse matrix
-                A_sparse = sp.csr_matrix(A)
-
                 # Dose constraints: A @ dwell_times - x_slack <= target_dose
-                target_dose_vec = np.full(num_dose_points, target_dose)
                 model.addConstr(
                     A_sparse @ t_MVar - x_slack <= target_dose_vec,
                     name=f"dose_oar_{structure.name}"
@@ -435,7 +441,10 @@ class DwellTimeOptimizer(BaseModel):
 
         # Set objective function
         model.setObjective(
-            penalty_terms["linear"] + penalty_terms["quadratic"] + penalty_terms["uniformity"],
+            penalty_terms["linear"]
+            + penalty_terms["quadratic"]
+            + penalty_terms["uniformity"]
+            + penalty_terms["hotspot"],
             GRB.MINIMIZE
         )
         model.update()

--- a/brachyutils/planning/optim_utils.py
+++ b/brachyutils/planning/optim_utils.py
@@ -348,7 +348,7 @@ class DwellTimeOptimizer(BaseModel):
 
             if not dose_rate_matrices:
                 continue
-            
+
             # conver the list of varaibles to a Gurobi variable Vector (MVar)
             t_MVar = MVar.fromlist(dwell_vars)
             # Stack dose rate matrices to create A matrix

--- a/brachyutils/tests/test_optim_utils.py
+++ b/brachyutils/tests/test_optim_utils.py
@@ -39,8 +39,8 @@ def test_run_optim():
             structure_name="ctv",
             dose_voxel_goal=dvh_metric_goals["D95%(ctv)"],
             penalty_weight_linear=300,
-            # penalty_weight_hotspot=1,
-            # hotspot_threshold=1.5,
+            penalty_weight_hotspot=1,
+            hotspot_threshold=1.5,
             mask_margin_mm=0,
             spacing_mm=3),
         Optimization_Config(


### PR DESCRIPTION
hot spot estimator terms were implemented in the Gurobi model using the matrix variables and matrix constraints. With this term, the number of zero dwell times was reduced from 40 to 24. the maximum dwell time was reduced from 51 seconds to 24 seconds.
Here are the results:

```bash
02/06/2025 07:44:29 PM - gurobipy - INFO - 
Optimal solution found.
{'D95%(ctv)': 19.823404947916664, 'CI(ctv)': 0.9462261876054979, 'HI(ctv)': 0.6271105750744849, 'D1cc(rectum)': 13.142664292279411, 'D0.1cc(urethra)': 23.288981119791664}
[ 0.         25.21847843  2.51430854  2.38045302  2.60386923 20.63102269
 31.37495631  0.          0.          0.          0.         11.79273733
  8.19771757  0.         16.14125516 44.7423568   0.         14.65494479
 69.25348232  3.73607977  2.05904258 17.86075073  8.87213268  3.75599641
  1.3437632   2.35346433  1.87314825  5.34148822  0.51476789  0.
  0.          0.          0.          0.          0.          5.43095109
  1.          0.          0.          0.          0.          0.
  2.         23.10814388  2.05152158  0.          0.          0.
 26.08075193 13.09546461  0.          0.58668384  8.78649197  0.99156866
  4.0176056   5.13550021  2.83930354  4.79016995  3.76048582  5.42084654
  7.65413634  0.          0.          0.          0.          0.
  3.          0.         11.6922434   9.8092917   0.          0.
  4.          0.          0.          0.         41.48043782  0.
  5.          1.39214407  9.51540989  0.         51.39498692  0.
  3.89028458  1.10339921 26.23244851 19.86510271  0.         23.81117281
 11.21522976 30.18842115  0.          0.         49.77609367  4.73315027
  7.07494676  0.         43.45598514]
```

40 zeros dwells

Here is the outcome of the optimization with the hot spot terms
```bash
02/06/2025 07:37:10 PM - gurobipy - INFO - 
Optimal solution found.
{'D95%(ctv)': 19.411376953125004, 'CI(ctv)': 0.9331142994936098, 'HI(ctv)': 0.6526617930514781, 'D1cc(rectum)': 12.705396569293477, 'D0.1cc(urethra)': 22.535536024305557}
[ 5.91548529  7.9789212   8.473182    9.13945481  1.55892953 17.73167532
 42.25099535  0.          0.          0.          0.89042613 10.20117935
  9.61705346 12.80606522  7.97183744 11.00209201  0.64099742 13.1658035
 11.01764788 10.72118463  6.55645172 12.07263267 11.10816257  2.89098586
  5.02289051  2.2680687   1.21115991  6.48610658  0.          0.
  0.          0.          0.          0.          0.          9.05925845
  2.46237184  0.          0.          0.          0.          0.
  1.         13.06394771 10.70460207  1.2422237   0.54897048  0.29235879
 56.77606177 15.42592459  0.          0.29829495  8.52353275  0.65285796
  9.03959836  4.17680299  3.05631839  4.44053024  5.44001588  6.01073936
 10.31357207  0.59481507  0.          0.          0.          0.
  2.          1.59094296 13.26183477 13.80950512  0.          0.
  3.          0.          0.          0.         19.49008484  8.36289399
  1.84548842  5.2995934   8.85063659  7.24675342 24.0853321   7.24822486
 10.80788838  7.36545015 18.0966168  22.30335041  0.         14.29672206
 10.63400675 18.03899684  4.81182071  6.60477108 14.01904773  7.53412145
  9.98908549  9.95802813 24.7335063 ]
```
24 zero dwells
