### PR TITLE
Bench dose calc

### DIFF
--- a/brachyutils/dose/dose_comparison_utils.py
+++ b/brachyutils/dose/dose_comparison_utils.py
@@ -492,7 +492,8 @@ class BrachyDoseComparison:
             local_vmax: float = 2.0,
             global_vmax: float = 0.1,
             pth_fig_save: Path | str = None,
-            fig_size_mm: tuple = (180, 140)
+            fig_size_mm: tuple = (180, 140),
+            title_fontsize: int = 14,
         ):
 
         """
@@ -672,7 +673,7 @@ class BrachyDoseComparison:
         axs_hist[0].set_xlabel(fr"$\Delta D_{{\mathrm{{LOCAL}}}} [\%]$", fontsize=10)
         axs_hist[1].set_xlabel(fr"$\Delta D_{{\mathrm{{GLOBAL}}}} [\%]$", fontsize=10)
 
-        fig.suptitle(plot_title, fontsize=20, fontweight="bold", y=0.98)
+        fig.suptitle(plot_title, fontsize=title_fontsize, fontweight="bold", y=0.98)
 
         if pth_fig_save is not None:
             pth_fig_save = Path(pth_fig_save)

--- a/brachyutils/dose/dose_comparison_utils.py
+++ b/brachyutils/dose/dose_comparison_utils.py
@@ -674,6 +674,7 @@ class BrachyDoseComparison:
 
         if pth_fig_save is not None:
             pth_fig_save = Path(pth_fig_save)
+            pth_fig_save.parent.mkdir(parents=True, exist_ok=True)
             fig.savefig(pth_fig_save, dpi=300)
         else:
             root = tk.Tk()

--- a/brachyutils/dose/dose_comparison_utils.py
+++ b/brachyutils/dose/dose_comparison_utils.py
@@ -44,7 +44,7 @@ class BrachyDoseComparison:
         "lower_percent_dose_cutoff": 5,
         "interp_fraction": 10,
         "local_gamma": False,
-        "global_normalisation": None,
+        # "global_normalisation": None,
         "skip_once_passed": True,
         "max_gamma": 1.1
     }
@@ -53,9 +53,10 @@ class BrachyDoseComparison:
         self,
         dose1: BrachyDose,
         dose2: BrachyDose,
-        gamma_dose_percent_threshold: float,
-        gamma_distance_threshold_mm: float,
+        gamma_dose_percent_threshold: float = 3.0,
+        gamma_distance_threshold_mm: float = 3.0,
         compute_percent_difference=True,
+        prescription_dose: float = None,
         compute_gamma_index=True,
         path=None,
         gamma_kwargs: dict = default_gamma_kwargs,
@@ -124,7 +125,12 @@ class BrachyDoseComparison:
         self.gamma_kwargs = BrachyDoseComparison.default_gamma_kwargs
         self.gamma_kwargs.update(gamma_kwargs) #in case the user wants to change the default
         self.plot_max_dose_percent_of_prescription : int = 200
-        self.prescription_dose = gamma_kwargs.get("global_normalisation", 1.0)
+        self.prescription_dose = (
+            gamma_kwargs.get("global_normalisation", 1.0) 
+            if prescription_dose is None 
+            else prescription_dose
+            )
+        self.gamma_kwargs["global_normalisation"] = self.prescription_dose
         self.max_gamma = gamma_kwargs.get("max_gamma", 1.1)
         self.percent_difference_range = percent_difference_range
         # axes values are assumed in cm from the 3ddose formalism
@@ -470,11 +476,22 @@ class BrachyDoseComparison:
             plane_coord: float,
             plane: str,
             plot_titles: tuple,
+            pth_fig_save: str = None,
         ):
 
-        """
-        Plot local and dose differences maps along both axes
+        r"""
+        ### Purpose:
+        - Plot local and dose differences maps along both axes
         With the histograms below
+        ### Inputs:
+        - axis_1_coords:= np.ndarray, the coordinates along the first axis in mm (e.g., x-axis)
+        - axis_2_coords:= np.ndarray, the coordinates along the second axis (e.g., y-axis)
+        - plane_coord:= float, the coordinate of the plane in which the profiles are extracted
+        - plane:= str, the plane in which the profiles are extracted (e.g., 'xy', 'xz', 'yz')
+        - plot_titles:= tuple, titles for the dose plots (dose 1 and dose 2)
+        - pth_save:= str, path to save the figure
+        ### Outputs:
+        - Displays and saves the figure with local and global percent difference maps and histograms
         """
 
         # from matplotlib.ticker import (
@@ -568,22 +585,25 @@ class BrachyDoseComparison:
         ax[1, 1].set_xlabel(fr"$\Delta D_{{\mathrm{{GLOBAL}}}} [\%]$", fontsize=10)
 
         #plt.subplots_adjust(left = 0.184, bottom = 0.136, right = 0.813, top = 0.892, wspace = 0.219, hspace = 0.222)
+        if pth_fig_save is not None:
+            plt.savefig(pth_fig_save, dpi=300)
 
-        plt.show()
+        else:
+            plt.show()
 
-        root = tk.Tk()
-        root.withdraw()
-        f = fd.asksaveasfile(
-            mode="wb",
-            defaultextension=".eps",
-            initialdir=os.getcwd(),
-            title="Save dose difference plots",
-            confirmoverwrite=True,
-        )
-        if f is not None:
-            ext = os.path.splitext(f.name)[1][1:]  # get extension without dot
-            plt.savefig(f, dpi=300, format=ext)
-            f.close()
-        root.destroy()
+            root = tk.Tk()
+            root.withdraw()
+            f = fd.asksaveasfile(
+                mode="wb",
+                defaultextension=".eps",
+                initialdir=os.getcwd(),
+                title="Save dose difference plots",
+                confirmoverwrite=True,
+            )
+            if f is not None:
+                ext = os.path.splitext(f.name)[1][1:]  # get extension without dot
+                plt.savefig(f, dpi=300, format=ext)
+                f.close()
+            root.destroy()
 
 

--- a/brachyutils/dose/dose_comparison_utils.py
+++ b/brachyutils/dose/dose_comparison_utils.py
@@ -492,6 +492,7 @@ class BrachyDoseComparison:
             local_vmax: float = 2.0,
             global_vmax: float = 0.1,
             pth_fig_save: Path | str = None,
+            fig_size_mm: tuple = (180, 140)
         ):
 
         """
@@ -530,7 +531,8 @@ class BrachyDoseComparison:
         # we will plot a figure that is suitable as a double column figure for medical physics
         mm = 1.0 / 25.4  # define millimeters (relative to inches=1)
         # Create two subfigures: top for images, bottom for histograms
-        fig = plt.figure(figsize=(180 * mm, 150 * mm))  # layout="compressed"
+        fig_size_mm = np.array(fig_size_mm) * mm
+        fig = plt.figure(figsize=fig_size_mm) # layout="compressed"
         subfigs = fig.subfigures(2, 1, height_ratios=[1, .75])
 
         fig.set_facecolor('lavender')

--- a/brachyutils/dose/dose_comparison_utils.py
+++ b/brachyutils/dose/dose_comparison_utils.py
@@ -490,7 +490,8 @@ class BrachyDoseComparison:
             plane: str,
             plot_title: str,
             local_vmax: float = 2.0,
-            global_vmax: float = 0.1
+            global_vmax: float = 0.1,
+            pth_fig_save: Path | str = None,
         ):
 
         """
@@ -671,25 +672,23 @@ class BrachyDoseComparison:
 
         fig.suptitle(plot_title, fontsize=20, fontweight="bold", y=0.98)
 
-
-        root = tk.Tk()
-        root.withdraw()
-        f = fd.asksaveasfile(
-            mode="wb",
-            defaultextension=".eps",
-            initialdir=os.getcwd(),
-            title="Save dose difference plots",
-            confirmoverwrite=True,
-        )
-        if f is not None:
-            ext = os.path.splitext(f.name)[1][1:]  # get extension without dot
-            fig.savefig(f, dpi=300, format=ext)
-            f.close()
+        if pth_fig_save is not None:
+            pth_fig_save = Path(pth_fig_save)
+            fig.savefig(pth_fig_save, dpi=300)
         else:
-            plt.show()
-        root.destroy()
-
-
-
-
-
+            root = tk.Tk()
+            root.withdraw()
+            f = fd.asksaveasfile(
+                mode="wb",
+                defaultextension=".eps",
+                initialdir=os.getcwd(),
+                title="Save dose difference plots",
+                confirmoverwrite=True,
+            )
+            if f is not None:
+                ext = os.path.splitext(f.name)[1][1:]  # get extension without dot
+                fig.savefig(f, dpi=300, format=ext)
+                f.close()
+            else:
+                plt.show()
+            root.destroy()

--- a/brachyutils/geometry/egsphant_utils.py
+++ b/brachyutils/geometry/egsphant_utils.py
@@ -790,6 +790,7 @@ class BrachyEgsphant:
         phantom_obj: BrachyPhantom,
         contour_name: str,
         inplace: Optional[bool] = True,
+        strict_name_match: Optional[bool] = True,
     ) -> Union[None, "BrachyEgsphant"]:
         r"""
         Purpose:
@@ -807,7 +808,7 @@ class BrachyEgsphant:
         )
         from opentps.core.processing.segmentation.segmentation3D import getBoxAroundROI
 
-        mask_dict = phantom_obj.get_structure_mask([contour_name], mask_type=ROIMask)
+        mask_dict = phantom_obj.get_structure_mask([contour_name], mask_type=ROIMask, strict_name_match=strict_name_match)
         resampled_mask = resampleImage3DOnImage3D(
             mask_dict[contour_name], self.density_image
         )

--- a/brachyutils/geometry/egsphant_utils.py
+++ b/brachyutils/geometry/egsphant_utils.py
@@ -542,7 +542,7 @@ class BrachyEgsphant:
 
     def write_to_nrrd(
         self,
-        fileName: Path,
+        fileName: Path | str,
         metadata: Optional[dict] = None,
         coordinate_system: Literal[
             "left-posterior-superior", "right-anterior-superior"
@@ -565,10 +565,8 @@ class BrachyEgsphant:
             note that 3D density files are written in z, y, x, but the sitk image is written in x, y, z.
         """
         # write out the files
-        assert os.path.exists(
-            os.path.dirname(fileName)
-        ), f"the input folder does not exist: {os.path.dirname(fileName)}"
-
+        fileName = Path(fileName)
+        Path.mkdir(fileName.parent, exist_ok=True, parents=True)
         # create sitk density image
         material_grid = self.get_material_array().astype(
             np.float32

--- a/brachyutils/geometry/phantom_utils.py
+++ b/brachyutils/geometry/phantom_utils.py
@@ -348,6 +348,7 @@ class BrachyPhantom:
         self,
         query_structure_list: List[str],
         mask_type: Union[np.ndarray, ROIContour, ROIMask] = ROIMask,
+        strict_name_match: bool = True,
     ) -> Dict[str, Union[np.ndarray, ROIContour, ROIMask]]:
         r"""
         ### Purpose:
@@ -378,7 +379,11 @@ class BrachyPhantom:
 
         for query_structure in flattened_query_structure_list:
             for mask_name in self.structure_names:
-                if query_structure.lower() == mask_name.lower():
+                if strict_name_match:
+                    pick_structure = query_structure.lower() == mask_name.lower()
+                else:
+                    pick_structure = query_structure.lower() in mask_name.lower()
+                if pick_structure:
                     mask = self.structure_set.getContourByName(mask_name).getBinaryMask(
                         origin=self.image_obj.origin,
                         gridSize=self.image_obj.gridSize,
@@ -640,6 +645,7 @@ class BrachyPhantom:
         resampled_spacing: List[float] = None,
         resampled_origin: List[float] = None,
         background_material: Optional[str] = "Air",
+        strict_name_match: bool = True,
     ) -> None:
         r"""
         Purpose:
@@ -685,7 +691,10 @@ class BrachyPhantom:
             )
   
             if crop_by_contour is not None:
-                self.egsphant_obj.crop_by_contour(phantom_used_for_egsphant, crop_by_contour)
+                self.egsphant_obj.crop_by_contour(
+                    phantom_used_for_egsphant,
+                    crop_by_contour,
+                    strict_name_match=strict_name_match)
 
             if resampled_spacing is not None:
                 self.egsphant_obj.material_image = resampleImage3D(

--- a/brachyutils/geometry/phantom_utils.py
+++ b/brachyutils/geometry/phantom_utils.py
@@ -700,11 +700,13 @@ class BrachyPhantom:
                 self.egsphant_obj.material_image = resampleImage3D(
                     image=self.egsphant_obj.material_image,
                     origin=resampled_origin,
-                    spacing=resampled_spacing, outputType=np.int16)
+                    spacing=resampled_spacing, 
+                    outputType=np.int16)
                 self.egsphant_obj.density_image = resampleImage3D(
                     image=self.egsphant_obj.density_image,
                     origin=resampled_origin,
-                    spacing=resampled_spacing)
+                    spacing=resampled_spacing,)
+                    # sitk_interpolator=sitk.sitkNearestNeighbor)
                 self.egsphant_obj.get_voxel_edges()
             if str(pth_output).endswith(".egsphant"):
                 self.egsphant_obj.write_to_ctegsphant(pth_output)

--- a/brachyutils/geometry/phantom_utils.py
+++ b/brachyutils/geometry/phantom_utils.py
@@ -644,6 +644,7 @@ class BrachyPhantom:
         crop_by_contour: str = None,
         resampled_spacing: List[float] = None,
         resampled_origin: List[float] = None,
+        resample_phantom_base: Optional[bool] = True,
         background_material: Optional[str] = "Air",
         strict_name_match: bool = True,
     ) -> None:
@@ -683,6 +684,15 @@ class BrachyPhantom:
         elif self.image_obj is not None:
             phantom_used_for_egsphant = deepcopy(self)
             from brachyutils.geometry.egsphant_utils import BrachyEgsphant
+            
+            if resampled_spacing is not None or resampled_origin is not None: #if we want to resample
+                if resample_phantom_base: #resample the phantom and structures that the egsphant is based on
+                    phantom_used_for_egsphant.resample_to(
+                        origin=resampled_origin,
+                        spacing=resampled_spacing,
+                        inplace=True
+                    )
+
             self.egsphant_obj = BrachyEgsphant(
                 phantom=phantom_used_for_egsphant,
                 material_dict=material_dict,
@@ -696,7 +706,7 @@ class BrachyPhantom:
                     crop_by_contour,
                     strict_name_match=strict_name_match)
 
-            if resampled_spacing is not None:
+            if resampled_spacing is not None and not resample_phantom_base:
                 self.egsphant_obj.material_image = resampleImage3D(
                     image=self.egsphant_obj.material_image,
                     origin=resampled_origin,
@@ -1090,7 +1100,7 @@ class BrachyPhantom:
         self,
         origin:np.array=None,
         spacing:np.array=None,
-        inplace:bool=False,
+        inplace:bool=True,
         gridSize:np.array=None,
         interpolator_img=sitk.sitkLinear) -> "BrachyPhantom":
         r"""

--- a/brachyutils/geometry/phantom_utils.py
+++ b/brachyutils/geometry/phantom_utils.py
@@ -639,7 +639,6 @@ class BrachyPhantom:
         crop_by_contour: str = None,
         resampled_spacing: List[float] = None,
         resampled_origin: List[float] = None,
-        resample_phantom_base: Optional[bool] = True,
         background_material: Optional[str] = "Air",
     ) -> None:
         r"""
@@ -678,14 +677,6 @@ class BrachyPhantom:
         elif self.image_obj is not None:
             phantom_used_for_egsphant = deepcopy(self)
             from brachyutils.geometry.egsphant_utils import BrachyEgsphant
-            if resampled_spacing is not None or resampled_origin is not None: #if we want to resample
-                if resample_phantom_base: #resample the phantom and structures that the egsphant is based on
-                    phantom_used_for_egsphant.resample_to(
-                        origin=resampled_origin,
-                        spacing=resampled_spacing,
-                        inplace=True
-                    )
-
             self.egsphant_obj = BrachyEgsphant(
                 phantom=phantom_used_for_egsphant,
                 material_dict=material_dict,
@@ -696,9 +687,15 @@ class BrachyPhantom:
             if crop_by_contour is not None:
                 self.egsphant_obj.crop_by_contour(phantom_used_for_egsphant, crop_by_contour)
 
-            if resampled_spacing is not None and not resample_phantom_base:
-                self.egsphant_obj.material_image = resampleImage3D(image=self.egsphant_obj.material_image, spacing=resampled_spacing, outputType=np.int16)
-                self.egsphant_obj.density_image = resampleImage3D(image=self.egsphant_obj.density_image, spacing=resampled_spacing)
+            if resampled_spacing is not None:
+                self.egsphant_obj.material_image = resampleImage3D(
+                    image=self.egsphant_obj.material_image,
+                    origin=resampled_origin,
+                    spacing=resampled_spacing, outputType=np.int16)
+                self.egsphant_obj.density_image = resampleImage3D(
+                    image=self.egsphant_obj.density_image,
+                    origin=resampled_origin,
+                    spacing=resampled_spacing)
                 self.egsphant_obj.get_voxel_edges()
             if str(pth_output).endswith(".egsphant"):
                 self.egsphant_obj.write_to_ctegsphant(pth_output)

--- a/brachyutils/planning/plan_utils.py
+++ b/brachyutils/planning/plan_utils.py
@@ -1716,16 +1716,18 @@ def load_dicom_to_plan(
     dose_dcm = dose_dcm[0] if len(dose_dcm) > 0 else None
     plan_dcm = plan_dcm[0] if len(plan_dcm) > 0 else None
     simulation_setup = kwargs.pop("simulation_setup", None)
-    if simulation_setup is None:
-        simulation_setup = plan_dcm
-    if isinstance(simulation_setup, dict):
-        if simulation_setup.get("brachy_source") is None:
-            simulation_setup["brachy_source"] = plan_dcm
+
+    new_sim_setup = deepcopy(simulation_setup) # this is to avoid memory reference issues during forloops
+    if new_sim_setup is None:
+        new_sim_setup = plan_dcm
+    if isinstance(new_sim_setup, dict):
+        if new_sim_setup.get("brachy_source") is None:
+            new_sim_setup["brachy_source"] = plan_dcm
     combined_dose = kwargs.pop("combined_dose", dose_dcm)
     return BrachyPlan(
         phantom=dir_dicom,
         catheter_table=plan_dcm,
         combined_dose=combined_dose,
-        simulation_setup=simulation_setup,
+        simulation_setup=new_sim_setup,
         **kwargs
     )

--- a/brachyutils/planning/plan_utils.py
+++ b/brachyutils/planning/plan_utils.py
@@ -1039,6 +1039,7 @@ class BrachyPlan:
                     material_dict=content_to_export.get("materials_table", None),
                     assign_material_from_ct=content_to_export.get("assign_material_from_ct", True),
                     crop_by_contour=content_to_export.get("crop_by_contour", None),
+                    strict_name_match=content_to_export.get("strict_name_match", True),
                     resampled_spacing=content_to_export.get("resampled_spacing", None),
                     resampled_origin=content_to_export.get("resampled_origin", None),
                     background_material=content_to_export.get("background_material", "Air"),
@@ -1286,7 +1287,8 @@ class BrachyPlan:
         crop_by_contour: str = None,
         resampled_spacing: List[float] = None,
         resampled_origin: List[float] = None,
-        background_material: str = None
+        background_material: str = None,
+        strict_name_match: bool = True
     ):
         r"""
         ### Purpose:
@@ -1318,7 +1320,8 @@ class BrachyPlan:
             crop_by_contour=crop_by_contour,
             resampled_spacing=resampled_spacing,
             resampled_origin=resampled_origin,
-            background_material=background_material
+            background_material=background_material,
+            strict_name_match=strict_name_match
         )
 
     def _export_applicator_geometry(

--- a/brachyutils/planning/plan_utils.py
+++ b/brachyutils/planning/plan_utils.py
@@ -154,6 +154,7 @@ class BrachyPlan:
         self.dvh_metric_goals: dict = None
         self.dvh_metrics_observed: dict = None
         self.structure_list: List[BrachyStructure] = []
+        self.body_contour: ROIContour = None
         self.phantom_origin: list = None  # np.array([0, 0, 0])  # x,y,z
         self.organ_bounds: list = None
 
@@ -701,6 +702,9 @@ class BrachyPlan:
                 dvh_metric_goals=dvh_metric_goals_by_structure[structure_name],
             )
             self.structure_list.append(structure_obj)
+        self.body_contour = phantom.get_structure_mask(
+            ["body"], ROIContour, strict_name_match=False
+        ).get("body", None)
 
     def load_applicator_list(
         self,
@@ -918,7 +922,9 @@ class BrachyPlan:
             observed_metrics = structure_obj.get_dvh_metric(
                 combined_dose,
                 prescription_dose,
-                return_percentage)
+                return_percentage,
+                self.body_contour,
+                )
             self.dvh_metrics_observed.update(observed_metrics)
         return self.dvh_metrics_observed
 

--- a/brachyutils/planning/plan_utils.py
+++ b/brachyutils/planning/plan_utils.py
@@ -83,6 +83,7 @@ class BrachyPlan:
         #### for structure creation:
         dvh_metric_goals: Union[dict, Path] = None,
         prescription_dose: float = None,
+        strict_name_match: bool = True,
         #### for loading catheter table and/or applicators:
         catheter_table: Union[Path, CatheterTable, str] = None,
         delivered_catheter_table: bool = False,
@@ -209,6 +210,7 @@ class BrachyPlan:
             self.create_brachy_structure_set(
                 phantom=self.phantom,
                 dvh_metric_goals=self.dvh_metric_goals,
+                strict_name_match=strict_name_match,
             )
 
         # load the catheter table if the path is provided
@@ -656,7 +658,10 @@ class BrachyPlan:
         self.dvh_metric_goals = dvh_metric_goals
 
     def create_brachy_structure_set(
-        self, phantom: BrachyPhantom, dvh_metric_goals: dict
+        self,
+        phantom: BrachyPhantom,
+        dvh_metric_goals: dict,
+        strict_name_match: bool = True,
     ):
         r"""
         ### Purpose:
@@ -685,7 +690,7 @@ class BrachyPlan:
             }
             dvh_metric_goals_by_structure[structure_name] = dvh_metric_goals_per_struct
         structure_masks: dict = phantom.get_structure_mask(
-            structure_names_in_dvh, ROIContour
+            structure_names_in_dvh, ROIContour, strict_name_match=strict_name_match
         )
         for structure_name in structure_masks.keys():
             structure_obj = BrachyStructure(

--- a/brachyutils/planning/simulation_utils.py
+++ b/brachyutils/planning/simulation_utils.py
@@ -255,7 +255,7 @@ class BrachySimulation(BaseModel):
             - None
         """
         return {
-            "source_dict": self.brachy_source.to_dict(),
+            "brachy_source": self.brachy_source.to_dict(),
             "world_material": self.world_material,
             "number_histories": self.number_histories,
             "total_time": self.total_time,

--- a/brachyutils/planning/structure_utils.py
+++ b/brachyutils/planning/structure_utils.py
@@ -101,6 +101,7 @@ class BrachyStructure:
         combined_dose: BrachyDose,
         prescription_dose: float = None,
         return_percentage: bool = False,
+        body_contour: ROIContour = None,
         ) -> Dict[str, float]:
         r"""
         ### Purpose:
@@ -115,6 +116,8 @@ class BrachyStructure:
         - prescription_dose := the prescribed dose to the target volume (PTV or CTV).
         - return_percentage := if true, the value of the dvh metric is normalized to
         the prescription dose for Dcc or D% and to the volume of the organName for VGy or V%.
+        - body_contour := the body contour is needed for conformity index calculation.
+        If the body contour is not provided, the conformity index will not be calculated.
         ### Outputs:
         - Void := will update the BrachyStructure.dvh_metrics_observed dictionary and
         BrachyStructure.dvh_obj attributes. Will also update the last calculated value
@@ -147,7 +150,7 @@ class BrachyStructure:
                         The metrics starting with 'D' should have percent sign (%) or cc.\
                         for example 'D95%(organ name)' or 'D2cc(organ name)'"
                     )
-                
+
             elif metric_string.startswith("V"):
                 if "%" in metric_string:
                     threshold = float(metric_string.split("%")[0].split("V")[-1])
@@ -163,8 +166,8 @@ class BrachyStructure:
                     ) 
             elif metric_string.startswith("HI"):
                 self.dvh_metrics_observed[dvh_metric_name] = self.dvh_obj.homogeneityIndex()
-            elif metric_string.startswith("CI"):
-                self.dvh_metrics_observed[dvh_metric_name] = self.dvh_obj.conformityIndex()
+            elif metric_string.startswith("CI") and body_contour is not None:
+                self.dvh_metrics_observed[dvh_metric_name] = self.dvh_obj.conformityIndex(body_contour)
             else:
                 raise ValueError(
                     "invalid name for DVH metric name. \

--- a/brachyutils/tests/test_cli_utils.py
+++ b/brachyutils/tests/test_cli_utils.py
@@ -37,8 +37,8 @@ def test_convert_phantom():
 
 def test_convert_egsphant():
     from brachyutils.cli_utils import convert_egsphant, EgsphantType
-    # dir_input = Path("data_test/prostate-glen-p1-planFiles/cropped_ct.egsphant")
-    dir_input = Path("data_test/test_export_plan/prostate/cropped_ct.seq.nrrd")
+    dir_input = Path("data_test/prostate-glen-p1-planFiles/cropped_ct.egsphant")
+    # dir_input = Path("data_test/test_export_plan/prostate/cropped_ct.seq.nrrd")
     dir_output = Path("data_test/test_export_plan/prostate")
     type_out = EgsphantType.EGS
 
@@ -51,5 +51,5 @@ def test_convert_egsphant():
 
 if __name__ == "__main__":
     # test_convert_dose()
-    test_convert_phantom()
-    # test_convert_egsphant()
+    # test_convert_phantom()
+    test_convert_egsphant()

--- a/brachyutils/tests/test_geometry_utils.py
+++ b/brachyutils/tests/test_geometry_utils.py
@@ -79,8 +79,18 @@ def test_read_structures_from_nrrd():
     # phantom_obj.write_image_to_nrrd(pth_out)
     phantom_obj.write_structures_to_nrrd(pth_out, overlap=True)
 
+def test_upsample_structure():
+    pth_dicom = "/home/ubuntu/YourLocalHome/Data/prostate/prostate-glen-2023/p8"
+    # pth_dicom = "data_test/prostate-glen-p1-dcm"
+    pth_structure = glob(pth_dicom + "/RS*.dcm")[0]
+    pth_out = "data_test/test_export_plan/prostate"
+    phantom_obj = BrachyPhantom(dir_dicom=pth_dicom, pth_structures_file=pth_structure)
+    phantom_obj.resample_to(spacing=np.array([1., 1., 1.]))
+    phantom_obj.export_to(dir_nrrd_out=pth_out)
+
 def test_write_to_egsphant():
-    pth_dicom = "data_test/prostate-glen-p1-dcm"
+    # pth_dicom = "data_test/prostate-glen-p1-dcm"
+    pth_dicom = "/home/ubuntu/YourLocalHome/Data/prostate/prostate-glen-2023/p8"
     pth_structure = glob(pth_dicom + "/RS*.dcm")[0]
     pth_out = "data_test/test_export_plan/prostate/ct.egsphant"
     # pth_materials = "data_test/prostate-glen-p1-dcm/CTtoDensityProstate.txt"
@@ -96,14 +106,15 @@ def test_write_to_egsphant():
         pth_output=pth_out,
         material_dict=pth_materials,
         assign_material_from_ct=assign_material_from_ct,
+        resampled_spacing=[1., 1., 1.],
     )
-    from brachyutils.geometry.egsphant_utils import BrachyEgsphant
-    egsphant_obj = BrachyEgsphant(pth_egsphant_file=pth_out)
-    egsphant_obj.write_to_file(Path(pth_out).parent.joinpath("egsphant.seq.nrrd"))
+    # from brachyutils.geometry.egsphant_utils import BrachyEgsphant
+    # egsphant_obj = BrachyEgsphant(pth_egsphant_file=pth_out)
+    # egsphant_obj.write_to_file(Path(pth_out).parent.joinpath("egsphant.seq.nrrd"))
 
-    new_egsphant = BrachyEgsphant(Path(pth_out).parent.joinpath("egsphant.seq.nrrd"))
-    new_egsphant.write_to_file(pth_out)
-    new_egsphant.is_equal(egsphant_obj)
+    # new_egsphant = BrachyEgsphant(Path(pth_out).parent.joinpath("egsphant.seq.nrrd"))
+    # new_egsphant.write_to_file(pth_out)
+    # new_egsphant.is_equal(egsphant_obj)
 
 def test_load_egsphant():
     pth_egsphant = "data_test/prostate-glen-p1-planFiles/ct.egsphant"
@@ -381,9 +392,10 @@ if __name__ == "__main__":
     # test_write_image_to_dicom()
     # test_write_image_to_nrrd()
     # test_write_structures_to_nrrd()
+    test_upsample_structure()
     # test_write_structures_to_dicom()
     # test_read_structures_from_nrrd()
-    test_write_to_egsphant()
+    # test_write_to_egsphant()
     # test_load_egsphant()
     # test_crop_phantom()
     # print("testing CatheterTable")

--- a/brachyutils/tests/test_geometry_utils.py
+++ b/brachyutils/tests/test_geometry_utils.py
@@ -80,8 +80,8 @@ def test_read_structures_from_nrrd():
     phantom_obj.write_structures_to_nrrd(pth_out, overlap=True)
 
 def test_upsample_structure():
-    pth_dicom = "/home/ubuntu/YourLocalHome/Data/prostate/prostate-glen-2023/p8"
-    # pth_dicom = "data_test/prostate-glen-p1-dcm"
+    # pth_dicom = "/home/ubuntu/YourLocalHome/Data/prostate/prostate-glen-2023/p8"
+    pth_dicom = "data_test/prostate-glen-p1-dcm"
     pth_structure = glob(pth_dicom + "/RS*.dcm")[0]
     pth_out = "data_test/test_export_plan/prostate"
     phantom_obj = BrachyPhantom(dir_dicom=pth_dicom, pth_structures_file=pth_structure)
@@ -89,8 +89,8 @@ def test_upsample_structure():
     phantom_obj.export_to(dir_nrrd_out=pth_out)
 
 def test_write_to_egsphant():
-    # pth_dicom = "data_test/prostate-glen-p1-dcm"
-    pth_dicom = "/home/ubuntu/YourLocalHome/Data/prostate/prostate-glen-2023/p8"
+    pth_dicom = "data_test/prostate-glen-p1-dcm"
+    # pth_dicom = "/home/ubuntu/YourLocalHome/Data/prostate/prostate-glen-2023/p8"
     pth_structure = glob(pth_dicom + "/RS*.dcm")[0]
     pth_out = "data_test/test_export_plan/prostate/ct.egsphant"
     # pth_materials = "data_test/prostate-glen-p1-dcm/CTtoDensityProstate.txt"
@@ -392,10 +392,10 @@ if __name__ == "__main__":
     # test_write_image_to_dicom()
     # test_write_image_to_nrrd()
     # test_write_structures_to_nrrd()
-    test_upsample_structure()
+    # test_upsample_structure()
     # test_write_structures_to_dicom()
     # test_read_structures_from_nrrd()
-    # test_write_to_egsphant()
+    test_write_to_egsphant()
     # test_load_egsphant()
     # test_crop_phantom()
     # print("testing CatheterTable")

--- a/docker_src/.env
+++ b/docker_src/.env
@@ -1,5 +1,5 @@
-# HOST_HOME=${HOME} # for local pc
-HOST_HOME=/Data/hosseinj # for proton
+HOST_HOME=${HOME} # for local pc
+# HOST_HOME=/Data/hosseinj # for proton
 QT_QPA_PLATFORM=offscreen
 UID=$(UID)
 GID=${GID}

--- a/docker_src/.env
+++ b/docker_src/.env
@@ -1,4 +1,5 @@
-HOST_HOME=${HOME}
+# HOST_HOME=${HOME} # for local pc
+HOST_HOME=/Data/hosseinj # for proton
 QT_QPA_PLATFORM=offscreen
 UID=$(UID)
 GID=${GID}

--- a/docker_src/command_docker.sh
+++ b/docker_src/command_docker.sh
@@ -12,7 +12,7 @@ export HOST_HOME=${HOME}
 # docker compose up --build -d BrachyUtils
 # # to run the container without building the image
 docker compose up --no-build -d BrachyUtils
-# docker compose up --no-build -d DoseCalcMC
+docker compose up --no-build -d DoseCalcMC
 docker compose up --no-build -d DoseCalcTG43
 # docker compose up --no-build -d Plastimatch
 # docker compose up --no-build -d SimpleElastix

--- a/docker_src/command_docker.sh
+++ b/docker_src/command_docker.sh
@@ -13,7 +13,7 @@ docker compose up --build -d BrachyUtils
 # # to run the container without building the image
 docker compose up --no-build -d BrachyUtils
 # docker compose up --no-build -d DoseCalcMC
-# docker compose up --no-build -d DoseCalcTG43
+docker compose up --no-build -d DoseCalcTG43
 # docker compose up --no-build -d Plastimatch
 # docker compose up --no-build -d SimpleElastix
 # to enter the container

--- a/docker_src/command_docker.sh
+++ b/docker_src/command_docker.sh
@@ -6,10 +6,10 @@ export GID=$(id -g)
 export DISPLAY=$DISPLAY
 export HOST_HOME=${HOME}
 # # to build the image and run the container
-export DOCKER_BUILDKIT=1
-echo $(ssh-agent)
-ssh-add ~/.ssh/id_rsa # to allow the container to access the host SSH keys
-docker compose up --build -d BrachyUtils
+# export DOCKER_BUILDKIT=1
+# echo $(ssh-agent)
+# ssh-add ~/.ssh/id_rsa # to allow the container to access the host SSH keys
+# docker compose up --build -d BrachyUtils
 # # to run the container without building the image
 docker compose up --no-build -d BrachyUtils
 # docker compose up --no-build -d DoseCalcMC

--- a/docker_src/command_docker.sh
+++ b/docker_src/command_docker.sh
@@ -4,7 +4,7 @@
 export UID=$(id -u)
 export GID=$(id -g)
 export DISPLAY=$DISPLAY
-export HOST_HOME=${HOME}
+# export HOST_HOME=${HOME}
 # # to build the image and run the container
 # export DOCKER_BUILDKIT=1
 # echo $(ssh-agent)
@@ -13,7 +13,7 @@ export HOST_HOME=${HOME}
 # # to run the container without building the image
 docker compose up --no-build -d BrachyUtils
 docker compose up --no-build -d DoseCalcMC
-docker compose up --no-build -d DoseCalcTG43
+# docker compose up --no-build -d DoseCalcTG43
 # docker compose up --no-build -d Plastimatch
 # docker compose up --no-build -d SimpleElastix
 # to enter the container

--- a/docker_src/command_docker.sh
+++ b/docker_src/command_docker.sh
@@ -12,7 +12,7 @@ export DISPLAY=$DISPLAY
 # docker compose up --build -d BrachyUtils
 # # to run the container without building the image
 docker compose up --no-build -d BrachyUtils
-docker compose up --no-build -d DoseCalcMC
+# docker compose up --no-build -d DoseCalcMC
 # docker compose up --no-build -d DoseCalcTG43
 # docker compose up --no-build -d Plastimatch
 # docker compose up --no-build -d SimpleElastix

--- a/docker_src/docker-compose.yaml
+++ b/docker_src/docker-compose.yaml
@@ -9,7 +9,7 @@ services:
         - HOST_HOME=${HOST_HOME}
     image: brachyutils
     container_name: BrachyUtils
-    user: 0:0 #"${UID}:${GID}"
+    user: "${UID}:${GID}"
     working_dir: /app
     stdin_open: true # docker run -i
     tty: true # docker run -t

--- a/docker_src/docker-compose.yaml
+++ b/docker_src/docker-compose.yaml
@@ -19,7 +19,7 @@ services:
       - QT_QPA_PLATFORM=offscreen
       - DISPLAY=${DISPLAY} # for access to graphical server
     volumes:
-      # - ${HOST_HOME}/Software/brachyutils:/app/Software/brachyutils
+      - ${HOST_HOME}/Software/brachyutils:/app/Software/brachyutils
       - ${HOST_HOME}:/home/ubuntu/YourLocalHome
       - /tmp/.X11-unix:/tmp/.X11-unix # for access to graphical server
     expose:

--- a/docker_src/docker-compose.yaml
+++ b/docker_src/docker-compose.yaml
@@ -9,7 +9,7 @@ services:
         - HOST_HOME=${HOST_HOME}
     image: brachyutils
     container_name: BrachyUtils
-    user: "${UID}:${GID}"
+    user: 0:0 #"${UID}:${GID}"
     working_dir: /app
     stdin_open: true # docker run -i
     tty: true # docker run -t

--- a/docker_src/docker-compose.yaml
+++ b/docker_src/docker-compose.yaml
@@ -9,7 +9,7 @@ services:
         - HOST_HOME=${HOST_HOME}
     image: brachyutils
     container_name: BrachyUtils
-    user: 0:0 #"${UID}:${GID}"
+    user: "0:0" #"${UID}:${GID}"
     working_dir: /app
     stdin_open: true # docker run -i
     tty: true # docker run -t
@@ -78,7 +78,7 @@ services:
   DoseCalcMC:
     image: rapidbrachy_mc
     container_name: DoseCalcMC
-    user: "${UID}:${GID}"
+    user: "0:0" # "${UID}:${GID}"
     working_dir: /app
     stdin_open: true # docker run -i
     tty: true # docker run -t

--- a/docker_src/docker-compose.yaml
+++ b/docker_src/docker-compose.yaml
@@ -86,14 +86,14 @@ services:
       - HOST_HOME=${HOST_HOME}
       - DEBIAN_FRONTEND=noninteractive
     volumes:
-      # - ${HOST_HOME}/Software/RapidBrachyMCTPS/RapidBrachyMC_Merge:/app/Software/RapidBrachyMCTPS/RapidBrachyMC_Merge
+      # - ${HOST_HOME}/Software/RapidBrachyMCTPS/RapidBrachyMC:/app/Software/RapidBrachyMCTPS/RapidBrachyMC
       # - ${HOST_HOME}:/app/YourLocalHome
-      - ${HOST_HOME}/Software/brachyutils/temp_data/mc:/app/Software/RapidBrachyMCTPS/RapidBrachyMC_Merge/temp_data
+      - ${HOST_HOME}/Software/brachyutils/temp_data/mc:/app/Software/RapidBrachyMCTPS/RapidBrachyMC/temp_data
     networks:
       net_brachyutils:
         ipv4_address: 192.168.1.11
     entrypoint: ["/bin/bash"]
-    command: ["/app/Software/RapidBrachyMCTPS/RapidBrachyMC_Merge/run_api.sh"]
+    command: ["/app/Software/RapidBrachyMCTPS/RapidBrachyMC/run_api.sh"]
 
   DoseCalcTG43:
     image: rapidbrachy_tg43

--- a/docker_src/docker-compose.yaml
+++ b/docker_src/docker-compose.yaml
@@ -9,7 +9,7 @@ services:
         - HOST_HOME=${HOST_HOME}
     image: brachyutils
     container_name: BrachyUtils
-    user: "0:0" #"${UID}:${GID}"
+    user: "${UID}:${GID}"
     working_dir: /app
     stdin_open: true # docker run -i
     tty: true # docker run -t
@@ -78,7 +78,7 @@ services:
   DoseCalcMC:
     image: rapidbrachy_mc
     container_name: DoseCalcMC
-    user: "0:0" # "${UID}:${GID}"
+    user: "${UID}:${GID}"
     working_dir: /app
     stdin_open: true # docker run -i
     tty: true # docker run -t

--- a/docker_src/repositories/install_ai_bt.sh
+++ b/docker_src/repositories/install_ai_bt.sh
@@ -3,6 +3,6 @@
 # dir_software=${HOME}/Software
 # # For docker image
 dir_software=/app/Software
-
+rm -rf ${dir_software}/AI_Assisted_Brachytherapy
 git clone git@github.com:engerlab/AI_Assisted_Brachytherapy.git ${dir_software}/AI_Assisted_Brachytherapy
 python3.13 -m pip install ${dir_software}/AI_Assisted_Brachytherapy

--- a/docker_src/repositories/install_opentps.sh
+++ b/docker_src/repositories/install_opentps.sh
@@ -4,6 +4,6 @@
 
 # # For docker image
 dir_software=/app/Software
-
+rm -rf ${dir_software}/OpenTPS-brachyutils
 git clone https://github.com/engerlab/OpenTPS-brachyutils ${dir_software}/OpenTPS-brachyutils
 python3.13 -m pip install ${dir_software}/OpenTPS-brachyutils

--- a/examples/benchmarks/eval_dose_generation.py
+++ b/examples/benchmarks/eval_dose_generation.py
@@ -611,6 +611,7 @@ def gen_percent_error_maps(
     dosimetry_inputs_mc: list[Dict[str, Union[str, Path]]],
     dosimetry_inputs_tg43: list[Dict[str, Union[str, Path]]],
     dir_output: Path | str,
+    z_coords_to_visualize: list[float] = None,
 ):
     r"""
     ### Purpose: To generate percent error maps and histograms between MC and TG43 
@@ -629,7 +630,7 @@ def gen_percent_error_maps(
     from brachyutils import BrachyDose
     from brachyutils import BrachyDoseComparison
 
-    for dosi_input in dosimetry_inputs_mc:
+    for dosi_input in tqdm(dosimetry_inputs_mc):
         plan_id = dosi_input.get("plan_id")
         # find corresponding tg43 input
         tg43_input = next((item for item in dosimetry_inputs_tg43 if item["plan_id"] == plan_id), None)
@@ -650,12 +651,17 @@ def gen_percent_error_maps(
         viz_index_limits = np.array([
             [len(vox_centers[0])*1/4, len(vox_centers[0])*3/4],
             [len(vox_centers[1])*1/4, len(vox_centers[1])*3/4],
-            ]
-        ).astype(int)
+            [len(vox_centers[2])//2, 0]
+        ]).astype(int)
+        # sometimes the best slice is not in the middle of the plane. Adjust if needed.
+        if plan_id in list(z_coords_to_visualize.keys()):
+            viz_index_limits[2][0] = np.abs(
+                vox_centers[2] - z_coords_to_visualize[plan_id]
+                ).argmin()
         dose_comp.plot_local_and_global_differences(
             axis_1_coords=vox_centers[0][viz_index_limits[0][0]:viz_index_limits[0][1]],
             axis_2_coords=vox_centers[1][viz_index_limits[1][0]:viz_index_limits[1][1]],
-            plane_coord=vox_centers[2][len(vox_centers[2])//2],
+            plane_coord=vox_centers[2][viz_index_limits[2][0]],
             plane="xy",
             plot_title=(f"MC vs TG43 Percent Error Map for Plan {plan_id}"),
             pth_fig_save=Path(dir_output)/f"percent_error_map_{plan_id}.svg",
@@ -663,8 +669,13 @@ def gen_percent_error_maps(
             global_vmax=10.0,
             fig_size_mm=(200, 160)
         )
+        # for debugging {
+        # if plan_id in ["p12", "p3", "p7", "p9"]:
+        #     dose_comp.write_percent_difference_to_nrrd(
+        #         dir=dir_output/f"percent_error_{plan_id}"
+        #     )
         # break; # for debugging
-
+        # }
 if __name__ == "__main__":
     # test_export()
     # test_dose_calc()
@@ -753,5 +764,11 @@ if __name__ == "__main__":
     gen_percent_error_maps(
         dosimetry_inputs_mc=dosimetry_inputs_mc,
         dosimetry_inputs_tg43=dosimetry_inputs_tg43,
-        dir_output=Path("temp_data/dose_error_maps/prostate-glen-2023")
+        dir_output=Path("temp_data/dose_error_maps/prostate-glen-2023"),
+        z_coords_to_visualize = {
+            "p12": -1199,
+            "p9": -1159,
+            "p7": -1154,
+            "p3": -1248,
+        }
     )

--- a/examples/benchmarks/eval_dose_generation.py
+++ b/examples/benchmarks/eval_dose_generation.py
@@ -422,12 +422,12 @@ if __name__ == "__main__":
     dir_export_mc = Path("temp_data/mc/prostate-glen-2023") # for Monte Carlo
 
     # export all dicoms to plans
-    for dir_export in [dir_export_tg43, dir_export_mc]:
-        run_export(
-            dir_all_dicoms=dir_all_dicoms,
-            dir_export=dir_export,
-            multi_proc=False,
-        )
+    # for dir_export in [dir_export_tg43, dir_export_mc]:
+    #     run_export(
+    #         dir_all_dicoms=dir_all_dicoms,
+    #         dir_export=dir_export,
+    #         multi_proc=False,
+    #     )
 
     # # run dose generation for all plans
     # run_dose_generation(

--- a/examples/benchmarks/eval_dose_generation.py
+++ b/examples/benchmarks/eval_dose_generation.py
@@ -647,9 +647,14 @@ def gen_percent_error_maps(
             positive_percent_difference=False,
         )
         vox_centers = dose_mc.get_voxel_centers()
+        viz_index_limits = np.array([
+            [len(vox_centers[0])*1/4, len(vox_centers[0])*3/4],
+            [len(vox_centers[1])*1/4, len(vox_centers[1])*3/4],
+            ]
+        ).astype(int)
         dose_comp.plot_local_and_global_differences(
-            axis_1_coords=vox_centers[0],
-            axis_2_coords=vox_centers[1],
+            axis_1_coords=vox_centers[0][viz_index_limits[0][0]:viz_index_limits[0][1]],
+            axis_2_coords=vox_centers[1][viz_index_limits[1][0]:viz_index_limits[1][1]],
             plane_coord=vox_centers[2][len(vox_centers[2])//2],
             plane="xy",
             plot_title=(f"MC vs TG43 Percent Error Map for Plan {plan_id}"),
@@ -747,5 +752,5 @@ if __name__ == "__main__":
     gen_percent_error_maps(
         dosimetry_inputs_mc=dosimetry_inputs_mc,
         dosimetry_inputs_tg43=dosimetry_inputs_tg43,
-        dir_output=Path("temp_data")
+        dir_output=Path("temp_data/dose_error_maps/prostate-glen-2023")
     )

--- a/examples/benchmarks/eval_dose_generation.py
+++ b/examples/benchmarks/eval_dose_generation.py
@@ -378,8 +378,8 @@ def scale_by_airkerma(dir_all_plans: str | Path, dir_all_dcms: str | Path):
             print(f"no plan dcm found for {plan}")
             continue
         pth_plan_dcm = pth_plan_dcm[0]
-        source_obj = BrachySource(source_dict=pth_plan_dcm)
-        scaling_factor = source_obj.reference_air_kerma_rate/5e4
+        source_obj = BrachySource(pth_source=pth_plan_dcm)
+        scaling_factor = source_obj.reference_air_kerma_rate/33142.4731805881
         
         pth_dose_list = list(plan.glob("*.nrrd"))
         def scale_dose(pth_dose: Path, scaling_factor: float):
@@ -387,17 +387,10 @@ def scale_by_airkerma(dir_all_plans: str | Path, dir_all_dcms: str | Path):
             dose_obj.set_dose_array(
                 dose_obj.get_dose_array()*scaling_factor
             )
-            dose_obj.write_brachydose_to_file(str(pth_dose.parent/f"scaled_{pth_dose.stem.stem}")+".seq.nrrd")
+            dose_obj.write_brachydose_to_file(pth_dose.parent / (str(pth_dose.name).split(".")[0]+".seq.nrrd"))
         print(f"scaling factor for {plan}: {scaling_factor}")
-        run_multi_proc(
-            partial(scale_dose, scaling_factor=scaling_factor),
-            pth_dose_list
-        )
-
-def run_scale_by_airkerma():
-    dir_all_plans = Path("temp_data/mc/prostate-glen-2023")
-    dir_all_dcms = Path("/root/YourLocalHome/Data/prostate-glen-2023")
-    scale_by_airkerma(dir_all_plans, dir_all_dcms)
+        for pth_dose in tqdm(pth_dose_list):
+            scale_dose(pth_dose, scaling_factor)
 
 def gen_dosimetry_inputs(
     dir_phnatoms: str | Path,
@@ -482,11 +475,18 @@ if __name__ == "__main__":
     #     method="mc"
     # )
     
+    # # this may be needed if the air kerma used in MC dose generation was incorrect
+    scale_by_airkerma(
+        # dir_all_plans=dir_export_tg43,        
+        dir_all_plans=dir_export_mc,
+        dir_all_dcms=dir_all_dicoms
+    )
+
     for dir_export in [
-        dir_export_tg43,
+        # dir_export_tg43,
         dir_export_mc,
-        dir_all_dicoms
-        ]:
+        # dir_all_dicoms
+        ]:        
         dosimetry_inputs = gen_dosimetry_inputs(
             dir_phnatoms=dir_all_dicoms,
             dir_doses=dir_export,
@@ -498,4 +498,4 @@ if __name__ == "__main__":
             pth_out_csv=dir_export/"dose_generation_dvh.csv",
             prescription_dose=prescription_dose
         )
-    # run_scale_by_airkerma()
+    

--- a/examples/benchmarks/eval_dose_generation.py
+++ b/examples/benchmarks/eval_dose_generation.py
@@ -663,7 +663,7 @@ def gen_percent_error_maps(
             global_vmax=10.0,
             fig_size_mm=(200, 160)
         )
-        break; # for debugging
+        # break; # for debugging
 
 if __name__ == "__main__":
     # test_export()

--- a/examples/benchmarks/eval_dose_generation.py
+++ b/examples/benchmarks/eval_dose_generation.py
@@ -412,6 +412,37 @@ def run_scale_by_airkerma():
     dir_all_dcms = Path("/root/YourLocalHome/Data/prostate-glen-2023")
     scale_by_airkerma(dir_all_plans, dir_all_dcms)
 
+def gen_dosimetry_inputs(
+    dir_phnatoms: str | Path,
+    dir_doses: str | Path
+):
+    r"""
+    ### Purpose:
+    to load phantoms (image + segementation) and combined doses of multiple patients
+    into a list of dictionaries, where the keys are patient number and the values are the 
+    paths.
+    """
+    list_phnatoms = list(Path(dir_phnatoms).glob("*/"))
+    list_doses = list(Path(dir_doses).glob("*/*combined.seq.nrrd"))
+    
+    plan_inputs_list = []
+    for dir_phant in list_phnatoms:
+        # find the right dose file
+        for dose_file in list_doses:
+            if dose_file.parent.name == dir_phant.name:
+                pth_dose = dose_file
+                break
+
+        plan_inputs_list.append(
+            {
+                "plan_id": dir_phant.name,
+                "pth_phant": dir_phant,
+                "pth_dose": pth_dose,
+                }
+            )
+        
+    return plan_inputs_list
+    
 if __name__ == "__main__":
     # test_export()
     # test_dose_calc()
@@ -434,9 +465,14 @@ if __name__ == "__main__":
     #     dir_plan_export=dir_export_tg43,
     #     method="tg43"
     # )
-    run_dose_generation(
-        dir_plan_export=dir_export_mc,
-        method="mc"
+    # run_dose_generation(
+    #     dir_plan_export=dir_export_mc,
+    #     method="mc"
+    # )
+    dosimetry_inputs = gen_dosimetry_inputs(
+        dir_phnatoms=dir_all_dicoms,
+        dir_doses=dir_export_tg43,
+        # dir_doses = dir_export_mc,
     )
-    # run_get_dvh_metrics_all_plans()
+    run_get_dvh_metrics_all_plans()
     # run_scale_by_airkerma()

--- a/examples/benchmarks/eval_dose_generation.py
+++ b/examples/benchmarks/eval_dose_generation.py
@@ -104,7 +104,7 @@ def run_export(
     else:
         for dicom in tqdm(all_dicoms):
             partially_filled_export_func(dicom)
-            # break # for debugging
+            break # for debugging
 
 def run_dose_generation(
     dir_plan_export: Path | str,
@@ -126,6 +126,7 @@ def run_dose_generation(
                 "dose_gen_method": "tg43",
                 "dose_generation_time": t1 - t0
             }
+            timing_data.to_csv(dir_plan_export/f"dose_generation_timing_{method}.csv", index=False)
             # break # for debugging
     # # for Monte Carlo
     elif method == "mc":
@@ -139,10 +140,9 @@ def run_dose_generation(
                 "dose_gen_method": "mc",
                 "dose_generation_time": t1 - t0
             }
+            timing_data.to_csv(dir_plan_export/f"dose_generation_timing_{method}.csv", index=False)
     else:
         raise ValueError(f"Invalid method: {method}. Valid methods are 'tg43' and 'mc'.")
-
-    timing_data.to_csv(dir_plan_export/f"dose_generation_timing_{method}.csv", index=False)
 
 def run_single_tg43_dose_generation(dir_plan):
     dose_gen_obj = DoseTG43(
@@ -421,20 +421,19 @@ if __name__ == "__main__":
     dir_export_tg43 = Path("temp_data/tg43/prostate-glen-2023") # for tg43
     dir_export_mc = Path("temp_data/mc/prostate-glen-2023") # for Monte Carlo
 
-    # # export all dicoms to plans
-    # for dir_export in [dir_export_tg43, dir_export_mc]:
-    #     run_export(
-    #         dir_all_dicoms=dir_all_dicoms,
-    #         dir_export=dir_export,
-    #         multi_proc=False,
-    #     )
-        # break
+    # export all dicoms to plans
+    for dir_export in [dir_export_tg43, dir_export_mc]:
+        run_export(
+            dir_all_dicoms=dir_all_dicoms,
+            dir_export=dir_export,
+            multi_proc=False,
+        )
 
     # # run dose generation for all plans
-    run_dose_generation(
-        dir_plan_export=dir_export_tg43,
-        method="tg43"
-    )
+    # run_dose_generation(
+    #     dir_plan_export=dir_export_tg43,
+    #     method="tg43"
+    # )
     # run_dose_generation(
     #     dir_plan_export=dir_export_mc,
     #     method="mc"

--- a/examples/benchmarks/eval_dose_generation.py
+++ b/examples/benchmarks/eval_dose_generation.py
@@ -661,6 +661,7 @@ def gen_percent_error_maps(
             pth_fig_save=Path(dir_output)/f"percent_error_map_{plan_id}.svg",
             local_vmax=20.0,
             global_vmax=10.0,
+            fig_size_mm=(200, 160)
         )
         break; # for debugging
 

--- a/examples/benchmarks/eval_dose_generation.py
+++ b/examples/benchmarks/eval_dose_generation.py
@@ -652,8 +652,10 @@ def gen_percent_error_maps(
             axis_2_coords=vox_centers[1],
             plane_coord=vox_centers[2][len(vox_centers[2])//2],
             plane="xy",
-            plot_titles=(f"MC vs TG43 Percent Error Map for Plan {plan_id}"),
-            pth_fig_save=Path(dir_output)/f"percent_error_map_{plan_id}.svg"
+            plot_title=(f"MC vs TG43 Percent Error Map for Plan {plan_id}"),
+            pth_fig_save=Path(dir_output)/f"percent_error_map_{plan_id}.svg",
+            local_vmax=20.0,
+            global_vmax=10.0,
         )
         break; # for debugging
 

--- a/examples/benchmarks/eval_dose_generation.py
+++ b/examples/benchmarks/eval_dose_generation.py
@@ -450,25 +450,26 @@ def gen_box_plots_dvh_timing(
     timing_mc = pd.read_csv(pth_timing_csv_mc)
     
     # merge dvh data with timing data based on plan_id
-    # data_tg43 = data_tg43.merge(timing_tg43, on="plan_id")
-    # data_mc = data_mc.merge(timing_mc, on="plan_id")
-    
+    data_tg43 = data_tg43.merge(timing_tg43, on="plan_id")
+    data_mc = data_mc.merge(timing_mc, on="plan_id")
+
     data_tg43.to_csv(pth_dvh_csv_tg43.parent/"dose_generation_data_tg43.csv", index=False)
     data_mc.to_csv(pth_dvh_csv_mc.parent/"dose_generation_data_mc.csv", index=False)
     
-    # generate the box plots then
+    # generate the box plots for V100% and V150%
     boxplot_tg43_mc(
-        data_tg43,
-        data_mc,
-        title = "DVH Metrics from RapidBrachy TG43 vs Monte Carlo Dose Calculation",
+        data_tg43[["V100%(ctv)", "V150%(ctv)"]],
+        data_mc[["V100%(ctv)", "V150%(ctv)"]],
+        title = "TG43 vs MC DVH Metrics",
         xlabel = "DVH Metrics",
-        ylabel = " Value [%]",
-        fig_size=(12, 8),
+        ylabel = "Volume Percentage [%]",
+        fig_size=(6, 4),
         alpha_tg43=0.5,
         alpha_mc=1.0,
-        box_color=(0.2, 0.4, 0.6),
-        font_size=16,
-        save_path=pth_dvh_csv_tg43.parent/"dose_generation_comparison_boxplots.svg"
+        box_color=(0.90,0.17,0.31),
+        font_size=14,
+        legend_loc="upper right",
+        save_path=pth_dvh_csv_tg43.parent.parent.parent/"boxplot_mc_tg43_Vx.svg"
     )
 
 def boxplot_tg43_mc(
@@ -482,6 +483,7 @@ def boxplot_tg43_mc(
     alpha_mc=1.0,
     box_color=(0, 0, 0),
     font_size=14,
+    legend_loc: str = "upper right",
     save_path: Path | str = None,
 ):
     """
@@ -566,7 +568,7 @@ def boxplot_tg43_mc(
         Patch(facecolor=box_color, alpha=alpha_tg43, label="TG43"),
         Patch(facecolor=box_color, alpha=alpha_mc, label="MC"),
     ]
-    ax.legend(handles=legend_elements, loc="upper left", fontsize=font_size - 2)
+    ax.legend(handles=legend_elements, loc=legend_loc, fontsize=font_size - 2)
 
     plt.tight_layout()
     if save_path:

--- a/examples/benchmarks/eval_dose_generation.py
+++ b/examples/benchmarks/eval_dose_generation.py
@@ -697,27 +697,27 @@ if __name__ == "__main__":
     }
     prescription_dose = 21 # in Gy
 
-    # # export all dicoms to plans
-    # for dir_export in [
-    #     dir_export_tg43,
-    #     dir_export_mc
-    #     # # dir_export_test
-    #     ]:
-    #     run_export(
-    #         dir_all_dicoms=dir_all_dicoms,
-    #         dir_export=dir_export,
-    #         multi_proc=False,
-    #     )
+    # export all dicoms to plans
+    for dir_export in [
+        dir_export_tg43,
+        dir_export_mc
+        # # dir_export_test
+        ]:
+        run_export(
+            dir_all_dicoms=dir_all_dicoms,
+            dir_export=dir_export,
+            multi_proc=False,
+        )
 
-    # # run dose generation for all plans
-    # run_dose_generation(
-    #     dir_plan_export=dir_export_tg43,
-    #     method="tg43"
-    # )
-    # run_dose_generation(
-    #     dir_plan_export=dir_export_mc,
-    #     method="mc"
-    # )
+    # run dose generation for all plans
+    run_dose_generation(
+        dir_plan_export=dir_export_tg43,
+        method="tg43"
+    )
+    run_dose_generation(
+        dir_plan_export=dir_export_mc,
+        method="mc"
+    )
 
     # # this may be needed if the air kerma used in MC dose generation was incorrect
     # scale_by_airkerma(
@@ -726,29 +726,29 @@ if __name__ == "__main__":
     #     dir_all_dcms=dir_all_dicoms
     # )
 
-    # for dir_export in [
-    #     # dir_export_tg43,
-    #     dir_export_mc,
-    #     # dir_all_dicoms
-    #     ]:
-    #     dosimetry_inputs = gen_dosimetry_inputs(
-    #         dir_phnatoms=dir_all_dicoms,
-    #         dir_doses=dir_export,
-    #         dose_format="nrrd" if dir_export != dir_all_dicoms else "dicom"
-    #     )
-    #     get_dvh_metrics_all_plans(
-    #         dosimetry_inputs=dosimetry_inputs,
-    #         dvh_metric_goals=dvh_metric_goals,
-    #         pth_out_csv=dir_export/"dose_generation_dvh.csv",
-    #         prescription_dose=prescription_dose
-    #     )
+    for dir_export in [
+        # dir_export_tg43,
+        dir_export_mc,
+        # dir_all_dicoms
+        ]:
+        dosimetry_inputs = gen_dosimetry_inputs(
+            dir_phnatoms=dir_all_dicoms,
+            dir_doses=dir_export,
+            dose_format="nrrd" if dir_export != dir_all_dicoms else "dicom"
+        )
+        get_dvh_metrics_all_plans(
+            dosimetry_inputs=dosimetry_inputs,
+            dvh_metric_goals=dvh_metric_goals,
+            pth_out_csv=dir_export/"dose_generation_dvh.csv",
+            prescription_dose=prescription_dose
+        )
 
-    # gen_box_plots_dvh_timing(
-    #     pth_dvh_csv_tg43=dir_export_tg43/"dose_generation_dvh.csv",
-    #     pth_dvh_csv_mc=dir_export_mc/"dose_generation_dvh.csv",
-    #     pth_timing_csv_tg43=dir_export_tg43/"dose_generation_timing.csv",
-    #     pth_timing_csv_mc=dir_export_mc/"dose_generation_timing.csv",
-    # )
+    gen_box_plots_dvh_timing(
+        pth_dvh_csv_tg43=dir_export_tg43/"dose_generation_dvh.csv",
+        pth_dvh_csv_mc=dir_export_mc/"dose_generation_dvh.csv",
+        pth_timing_csv_tg43=dir_export_tg43/"dose_generation_timing.csv",
+        pth_timing_csv_mc=dir_export_mc/"dose_generation_timing.csv",
+    )
 
     dosimetry_inputs_tg43 = gen_dosimetry_inputs(
         dir_phnatoms=dir_all_dicoms,

--- a/examples/benchmarks/eval_dose_generation.py
+++ b/examples/benchmarks/eval_dose_generation.py
@@ -49,7 +49,6 @@ def export_single_dicom_to_plan(
         dir_export=dir_export_plan,
         content_to_export=content_to_export,
     )
-    return dir_export_plan
 
 def run_export(
     dir_all_dicoms: Path | str,
@@ -59,9 +58,6 @@ def run_export(
     from functools import partial
     dir_all_dicoms = Path(dir_all_dicoms)
     dir_export = Path(dir_export)
-    # dir_all_dicoms = Path.home().joinpath("YourLocalHome/Data/prostate/prostate-glen-2023")
-    # dir_export = Path("temp_data/tg43/prostate-glen-2023")
-    # dir_export = Path("temp_data/mc/prostate-glen-2023")
 
     # pth_material = Path("admin/constants/CTtoDensityProstate.txt")
     # mat_from_ct = True
@@ -93,19 +89,23 @@ def run_export(
     }
     dir_export.mkdir(parents=True, exist_ok=True)
     all_dicoms = list(dir_all_dicoms.glob("*/"))
-    partially_filled_export_func = partial(
-        export_single_dicom_to_plan,
-        dir_export=dir_export,
-        sim_dict=sim_dict,
-        content_to_export=content_to_export,
-        )
 
     if multi_proc:
+        partially_filled_export_func = partial(
+            export_single_dicom_to_plan,
+            dir_export=dir_export,
+            sim_dict=sim_dict,
+            content_to_export=content_to_export,
+            )
         run_multi_proc(partially_filled_export_func, all_dicoms)
     else:
         for dicom in tqdm(all_dicoms):
-            partially_filled_export_func(dicom)
-            # break # for debugging
+            export_single_dicom_to_plan(
+                dir_dicom=dicom,
+                dir_export=dir_export,
+                sim_dict=sim_dict,
+                content_to_export=content_to_export,
+            )
 
 def run_dose_generation(
     dir_plan_export: Path | str,
@@ -170,7 +170,7 @@ def get_dvh_metrics_single_plan(
     r"""
     ### Purpose:
         - To evaluate a single plan's dose distribution based on DVH metrics.
-    
+
     ### Inputs:
         - dir_dose_rate: Path | str: The path to the exported plan.
         - dvh_metric_goals: Dict[str, float]: The DVH metrics to evaluate the plan.
@@ -445,6 +445,7 @@ if __name__ == "__main__":
     dir_all_dicoms = Path("/home/ubuntu").joinpath("YourLocalHome/Data/prostate/prostate-glen-2023")
     dir_export_tg43 = Path("temp_data/tg43/prostate-glen-2023") # for tg43
     dir_export_mc = Path("temp_data/mc/prostate-glen-2023") # for Monte Carlo
+    dir_export_test = Path("temp_data/test/prostate-glen-2023")
     dvh_metric_goals = {
         "V100%(ctv)": 95,
         "D90%(ctv)": 21,
@@ -457,13 +458,17 @@ if __name__ == "__main__":
     }
     prescription_dose = 21 # in Gy
 
-    # export all dicoms to plans
-    # for dir_export in [dir_export_tg43, dir_export_mc]:
-    #     run_export(
-    #         dir_all_dicoms=dir_all_dicoms,
-    #         dir_export=dir_export,
-    #         multi_proc=False,
-    #     )
+    # # export all dicoms to plans
+    for dir_export in [
+        # dir_export_tg43,
+        # dir_export_mc
+        dir_export_test
+        ]:
+        run_export(
+            dir_all_dicoms=dir_all_dicoms,
+            dir_export=dir_export,
+            multi_proc=False,
+        )
 
     # # run dose generation for all plans
     # run_dose_generation(
@@ -474,28 +479,27 @@ if __name__ == "__main__":
     #     dir_plan_export=dir_export_mc,
     #     method="mc"
     # )
-    
-    # # this may be needed if the air kerma used in MC dose generation was incorrect
-    scale_by_airkerma(
-        # dir_all_plans=dir_export_tg43,        
-        dir_all_plans=dir_export_mc,
-        dir_all_dcms=dir_all_dicoms
-    )
 
-    for dir_export in [
-        # dir_export_tg43,
-        dir_export_mc,
-        # dir_all_dicoms
-        ]:        
-        dosimetry_inputs = gen_dosimetry_inputs(
-            dir_phnatoms=dir_all_dicoms,
-            dir_doses=dir_export,
-            dose_format="nrrd" if dir_export != dir_all_dicoms else "dicom"
-        )
-        get_dvh_metrics_all_plans(
-            dosimetry_inputs=dosimetry_inputs,
-            dvh_metric_goals=dvh_metric_goals,
-            pth_out_csv=dir_export/"dose_generation_dvh.csv",
-            prescription_dose=prescription_dose
-        )
-    
+    # # this may be needed if the air kerma used in MC dose generation was incorrect
+    # scale_by_airkerma(
+    #     # dir_all_plans=dir_export_tg43,        
+    #     dir_all_plans=dir_export_mc,
+    #     dir_all_dcms=dir_all_dicoms
+    # )
+
+    # for dir_export in [
+    #     # dir_export_tg43,
+    #     dir_export_mc,
+    #     # dir_all_dicoms
+    #     ]:
+    #     dosimetry_inputs = gen_dosimetry_inputs(
+    #         dir_phnatoms=dir_all_dicoms,
+    #         dir_doses=dir_export,
+    #         dose_format="nrrd" if dir_export != dir_all_dicoms else "dicom"
+    #     )
+    #     get_dvh_metrics_all_plans(
+    #         dosimetry_inputs=dosimetry_inputs,
+    #         dvh_metric_goals=dvh_metric_goals,
+    #         pth_out_csv=dir_export/"dose_generation_dvh.csv",
+    #         prescription_dose=prescription_dose
+    #     )

--- a/examples/benchmarks/eval_dose_generation.py
+++ b/examples/benchmarks/eval_dose_generation.py
@@ -436,7 +436,15 @@ def gen_dosimetry_inputs(
             )
         
     return plan_inputs_list
-    
+
+def gen_box_plots_dvh_timing(
+    pth_dvh_csv_tg43: Path | str,
+    pth_dvh_csv_mc: Path | str,
+    pth_timing_csv_tg43: Path | str,
+    pth_timing_csv_mc: Path | str,
+):
+    pass
+
 if __name__ == "__main__":
     # test_export()
     # test_dose_calc()
@@ -459,16 +467,16 @@ if __name__ == "__main__":
     prescription_dose = 21 # in Gy
 
     # # export all dicoms to plans
-    for dir_export in [
-        # dir_export_tg43,
-        # dir_export_mc
-        dir_export_test
-        ]:
-        run_export(
-            dir_all_dicoms=dir_all_dicoms,
-            dir_export=dir_export,
-            multi_proc=False,
-        )
+    # for dir_export in [
+    #     dir_export_tg43,
+    #     dir_export_mc
+    #     # # dir_export_test
+    #     ]:
+    #     run_export(
+    #         dir_all_dicoms=dir_all_dicoms,
+    #         dir_export=dir_export,
+    #         multi_proc=False,
+    #     )
 
     # # run dose generation for all plans
     # run_dose_generation(
@@ -503,3 +511,10 @@ if __name__ == "__main__":
     #         pth_out_csv=dir_export/"dose_generation_dvh.csv",
     #         prescription_dose=prescription_dose
     #     )
+
+    gen_box_plots_dvh_timing(
+        pth_dvh_csv_tg43=dir_export_tg43/"dose_generation_dvh.csv",
+        pth_dvh_csv_mc=dir_export_mc/"dose_generation_dvh.csv",
+        pth_timing_csv_tg43=dir_export_tg43/"dose_generation_time.csv",
+        pth_timing_csv_mc=dir_export_mc/"dose_generation_time.csv",
+    )

--- a/examples/benchmarks/eval_dose_generation.py
+++ b/examples/benchmarks/eval_dose_generation.py
@@ -4,6 +4,7 @@ from tqdm import tqdm
 from brachyutils import load_dicom_to_plan
 from brachyutils import DoseMonteCarlo, DoseTG43
 import pandas as pd
+from time import time
 
 def run_multi_proc(function, input_list, max_workers=8):
     from multiprocessing import Pool
@@ -105,20 +106,41 @@ def run_export(
             partially_filled_export_func(dicom)
             # break # for debugging
 
-def run_dose_generation():
+def run_dose_generation(
+    dir_plan_export: Path | str,
+    method: Literal["tg43", "mc"] = "tg43",
+):
+    timing_data = pd.DataFrame(columns=[
+        "plan_name", "dose_gen_method", "dose_generation_time"
+        ])
     # # for TG43
+    if method == "tg43":
     # dir_plan_export = Path("temp_data/tg43/prostate-glen-2023")
-    # list_plans = list(dir_plan_export.glob("*/"))
-    # for plan in tqdm(list_plans):
-    #     run_single_tg43_dose_generation(plan)
+        dir_plans = list(dir_plan_export.glob("*/"))
+        for plan in tqdm(dir_plans):
+            t0 = time()
+            run_single_tg43_dose_generation(plan)
+            t1 = time()
+            timing_data.loc[len(timing_data)] = {
+                "plan_name": plan.name,
+                "dose_gen_method": "tg43",
+                "dose_generation_time": t1 - t0
+            }
+    elif method == "mc":
+        dir_plans = list(dir_plan_export.glob("*/"))
+        for plan in tqdm(dir_plans):
+            t0 = time()
+            run_single_mc_dose_generation(plan)
+            t1 = time()
+            timing_data.loc[len(timing_data)] = {
+                "plan_name": plan.name,
+                "dose_gen_method": "mc",
+                "dose_generation_time": t1 - t0
+            }
+    else:
+        raise ValueError(f"Invalid method: {method}. Valid methods are 'tg43' and 'mc'.")
 
-    # # for monte carlo
-    dir_plan_export = Path("temp_data/mc/prostate-glen-2023")
-    list_plans = list(dir_plan_export.glob("*/"))
-    for plan in tqdm(list_plans):
-        run_single_mc_dose_generation(plan)
-        break
-    # run_multi_proc(run_single_tg43_dose_generation, list_plans, max_workers=8)
+    timing_data.to_csv(dir_plan_export/f"dose_generation_timing_{method}.csv", index=False)
 
 def run_single_tg43_dose_generation(dir_plan):
     dose_gen_obj = DoseTG43(
@@ -403,6 +425,13 @@ if __name__ == "__main__":
             multi_proc=False,
         )
         # break
-    # run_dose_generation()
+    run_dose_generation(
+        dir_plan_export=dir_export_tg43,
+        method="tg43"
+    )
+    # run_dose_generation(
+    #     dir_plan_export=dir_export_mc,
+    #     method="mc"
+    # )
     # run_get_dvh_metrics_all_plans()
     # run_scale_by_airkerma()

--- a/examples/benchmarks/eval_dose_generation.py
+++ b/examples/benchmarks/eval_dose_generation.py
@@ -253,7 +253,7 @@ def get_dvh_metrics_all_plans(
     ### Outputs:
     - A csv file containing the dvh metrics for all the patients.
     """
-    all_dvhs = pd.DataFrame(columns=list(dvh_metric_goals.keys()))
+    all_dvhs = pd.DataFrame(columns=list(dvh_metric_goals.keys())+["plan_id"])
     for dir_plan in tqdm(dosimetry_inputs):
         print(f"dvh from dicom folder: {dir_plan.get('pth_phant')}")
         dvh_metrics = get_dvh_metrics_single_plan(
@@ -264,12 +264,9 @@ def get_dvh_metrics_all_plans(
             export_combined_dose=False,
             prescription_dose=prescription_dose
         )
+        all_dvhs.loc[len(all_dvhs)] = {"plan_id": dir_plan.get('plan_id')} | dvh_metrics
 
-        # except Exception as e:
-        #     print(f"error in getting dvh for {dir_plan}")
-        #     print(e)
-    all_dvhs.set_index("name", inplace=True)
-    all_dvhs.to_csv(pth_out_csv)
+    all_dvhs.to_csv(pth_out_csv, index=False)
 
 def test_get_dvh_metrics_single_plan():
     pth_single_dicom = Path("/root/YourLocalHome/Data/prostate-glen-2023/p2")
@@ -471,15 +468,16 @@ if __name__ == "__main__":
     #     dir_plan_export=dir_export_mc,
     #     method="mc"
     # )
-    dosimetry_inputs = gen_dosimetry_inputs(
-        dir_phnatoms=dir_all_dicoms,
-        dir_doses=dir_export_tg43,
-        # dir_doses = dir_export_mc,
-    )
-    get_dvh_metrics_all_plans(
-        dosimetry_inputs=dosimetry_inputs,
-        dvh_metric_goals=dvh_metric_goals,
-        pth_out_csv=dir_export_tg43,
-        prescription_dose=prescription_dose
-    )
+    
+    for dir_export in [dir_export_tg43, dir_export_mc]:
+        dosimetry_inputs = gen_dosimetry_inputs(
+            dir_phnatoms=dir_all_dicoms,
+            dir_doses=dir_export,
+        )
+        get_dvh_metrics_all_plans(
+            dosimetry_inputs=dosimetry_inputs,
+            dvh_metric_goals=dvh_metric_goals,
+            pth_out_csv=dir_export/"dose_generation_dvh.csv",
+            prescription_dose=prescription_dose
+        )
     # run_scale_by_airkerma()

--- a/examples/benchmarks/eval_dose_generation.py
+++ b/examples/benchmarks/eval_dose_generation.py
@@ -224,7 +224,7 @@ def get_dvh_metrics_single_plan(
                             are 'dicom', a path to a dose file or directory containing\
                             dose files per dwell position.")
 
-    dvh_metrics_observed = plan_obj.get_dvh_metrics()
+    dvh_metrics_observed = plan_obj.get_dvh_metrics(return_percentage=True)
     if export_combined_dose:
         plan_obj.export_brachy_plan(
             dir_export=dir_dose_rate,
@@ -254,9 +254,8 @@ def get_dvh_metrics_all_plans(
     - A csv file containing the dvh metrics for all the patients.
     """
     all_dvhs = pd.DataFrame(columns=list(dvh_metric_goals.keys()))
-    for dir_plan in dosimetry_inputs:
+    for dir_plan in tqdm(dosimetry_inputs):
         print(f"dvh from dicom folder: {dir_plan.get('pth_phant')}")
-        # try:
         dvh_metrics = get_dvh_metrics_single_plan(
             dir_dicom=dir_plan.get('pth_phant'),
             dvh_metric_goals=dvh_metric_goals,
@@ -445,7 +444,7 @@ if __name__ == "__main__":
     dir_export_mc = Path("temp_data/mc/prostate-glen-2023") # for Monte Carlo
     dvh_metric_goals = {
         "V100%(ctv)": 95,
-        "D90%(ctv)": 15,
+        "D90%(ctv)": 21,
         "V150%(ctv)": 40,
         "HI(ctv)": 1,
         "CI(ctv)": 1,
@@ -453,7 +452,7 @@ if __name__ == "__main__":
         "D10%(urethra)":17,
         "D30%(urethra)": 15,
     }
-    prescription_dose = 15 # in Gy
+    prescription_dose = 21 # in Gy
 
     # export all dicoms to plans
     # for dir_export in [dir_export_tg43, dir_export_mc]:

--- a/examples/benchmarks/eval_dose_generation.py
+++ b/examples/benchmarks/eval_dose_generation.py
@@ -104,7 +104,7 @@ def run_export(
     else:
         for dicom in tqdm(all_dicoms):
             partially_filled_export_func(dicom)
-            break # for debugging
+            # break # for debugging
 
 def run_dose_generation(
     dir_plan_export: Path | str,
@@ -434,9 +434,9 @@ if __name__ == "__main__":
     #     dir_plan_export=dir_export_tg43,
     #     method="tg43"
     # )
-    # run_dose_generation(
-    #     dir_plan_export=dir_export_mc,
-    #     method="mc"
-    # )
+    run_dose_generation(
+        dir_plan_export=dir_export_mc,
+        method="mc"
+    )
     # run_get_dvh_metrics_all_plans()
     # run_scale_by_airkerma()

--- a/examples/benchmarks/eval_dose_generation.py
+++ b/examples/benchmarks/eval_dose_generation.py
@@ -81,6 +81,7 @@ def run_export(
         "materials_table": pth_material,
         "assign_material_from_ct": mat_from_ct,
         "resampled_spacing": [1., 1., 1.],
+        "strict_name_match": False,
         "crop_by_contour": crop_by_contour,
         "plan": True,
         "mac": True,
@@ -102,7 +103,7 @@ def run_export(
     else:
         for dicom in tqdm(all_dicoms):
             partially_filled_export_func(dicom)
-            break # for debugging
+            # break # for debugging
 
 def run_dose_generation():
     # # for TG43
@@ -392,15 +393,16 @@ if __name__ == "__main__":
     # test_dose_calc()
     # test_get_dvh_metrics_single_plan()
     
-    dir_all_dicoms = Path.home().joinpath("YourLocalHome/Data/prostate/prostate-glen-2023")
-    dir_export = Path("temp_data/tg43/prostate-glen-2023") # for tg43
-    dir_export = Path("temp_data/mc/prostate-glen-2023") # for Monte Carlo
-    for dir_pth in [dir_all_dicoms, dir_export]:
+    dir_all_dicoms = Path("/home/ubuntu").joinpath("YourLocalHome/Data/prostate/prostate-glen-2023")
+    dir_export_tg43 = Path("temp_data/tg43/prostate-glen-2023") # for tg43
+    dir_export_mc = Path("temp_data/mc/prostate-glen-2023") # for Monte Carlo
+    for dir_export in [dir_export_tg43, dir_export_mc]:
         run_export(
             dir_all_dicoms=dir_all_dicoms,
             dir_export=dir_export,
             multi_proc=False,
         )
+        # break
     # run_dose_generation()
     # run_get_dvh_metrics_all_plans()
     # run_scale_by_airkerma()

--- a/examples/benchmarks/eval_dose_generation.py
+++ b/examples/benchmarks/eval_dose_generation.py
@@ -159,16 +159,18 @@ def run_single_mc_dose_generation(dir_plan):
 def get_dvh_metrics_single_plan(
     dir_dicom: Path | str,
     dvh_metric_goals: Dict[str, float],
-    dir_plan_export: Path | str,
+    prescription_dose: float,
     load_dose_from: Literal["dicom"] | Path | str = "dicom",
+    dir_dose_rate: Path | str = None,
     export_combined_dose: bool = True,
+
 ) -> Dict[str, float]:
     r"""
     ### Purpose:
         - To evaluate a single plan's dose distribution based on DVH metrics.
     
     ### Inputs:
-        - dir_plan_export: Path | str: The path to the exported plan.
+        - dir_dose_rate: Path | str: The path to the exported plan.
         - dvh_metric_goals: Dict[str, float]: The DVH metrics to evaluate the plan.
         - dir_dicom: Path | str: The path to the dicom directory for one plan. it should have images,
         and structure file.
@@ -182,6 +184,7 @@ def get_dvh_metrics_single_plan(
             load_dicom_dose=True,
             dvh_metric_goals=dvh_metric_goals,
             combined_dose_only=True,
+            prescription_dose=prescription_dose,
             )
     elif isinstance(load_dose_from, str) or isinstance(load_dose_from, Path):
         load_dose_from = Path(load_dose_from)
@@ -190,7 +193,8 @@ def get_dvh_metrics_single_plan(
                 dir_dicom=dir_dicom,
                 load_dicom_dose=False,
                 dvh_metric_goals=dvh_metric_goals,
-                combined_dose = load_dose_from,
+                prescription_dose=prescription_dose,
+                combined_dose=load_dose_from,
                 combined_dose_only=True,
                 multi_processing=True
                 )
@@ -199,7 +203,8 @@ def get_dvh_metrics_single_plan(
             dir_dicom=dir_dicom,
             load_dicom_dose=False,
             dvh_metric_goals=dvh_metric_goals,
-            dir_dose_rate=dir_plan_export,
+            prescription_dose=prescription_dose,
+            dir_dose_rate=dir_dose_rate,
             combined_dose_only=True,
             multi_processing=True
             )
@@ -215,7 +220,7 @@ def get_dvh_metrics_single_plan(
     dvh_metrics_observed = plan_obj.get_dvh_metrics()
     if export_combined_dose:
         plan_obj.export_brachy_plan(
-            dir_export=dir_plan_export,
+            dir_export=dir_dose_rate,
             content_to_export={
                 "dose": True,
             }
@@ -223,68 +228,42 @@ def get_dvh_metrics_single_plan(
     return dvh_metrics_observed
 
 def get_dvh_metrics_all_plans(
-    dir_all_dicom_folders: str | Path,
-    dir_all_plan_folders: str | Path,
+    dosimetry_inputs: list[Dict[str, Union[str, Path]]],
     dvh_metric_goals: Dict[str, float],
+    pth_out_csv: Path,
+    prescription_dose: float = None,
 ):
     r"""
     ### Purpose:
-        - To get the dvh metrics from all the patients in the given directory.
-    
+    - To get the dvh metrics from all the patients in the given directory.
     ### Inputs:
-        - dir_dicom_folders: str | Path: The path to the dicom folders.
-        - dir_plan_folders: str | Path: The path to the plan folders.
-        - dvh_metric_goals: Dict[str, float]: The DVH metrics to evaluate the plan.
+    - dosimetry_inputs:= list of dictionaries, where each dictionary contains the following keys:
+        - plan_id:= str, the patient id
+        - pth_phant:= Path, the path to the phantom directory
+        - pth_dose:= Path, the path to the dose file
+    - dvh_metric_goals:= Dict[str, float], the dvh metrics to evaluate the plans.
+    - pth_out_csv:= Path, the path to the output csv file.
+    ### Outputs:
+    - A csv file containing the dvh metrics for all the patients.
     """
-    dir_all_dicom_folders = Path(dir_all_dicom_folders)
-    dir_all_plan_folders = Path(dir_all_plan_folders)
-    
-    list_dir_plan = dir_all_plan_folders.glob("*/")
-    all_dvhs = pd.DataFrame()
-    for dir_plan in list_dir_plan:
-        if not dir_plan.is_dir():
-            continue
-        dir_dicom = dir_all_dicom_folders.joinpath(dir_plan.stem)
-        print(f"dvh from dicom folder: {dir_dicom}")
-        try:
-            dvh_metrics = get_dvh_metrics_single_plan(
-                dir_dicom=dir_dicom,
-                dvh_metric_goals=dvh_metric_goals,
-                dir_plan_export=dir_plan,
-                load_dose_from=dir_plan/"combined.seq.nrrd",
-                export_combined_dose=False,
-            )
-            all_dvhs = pd.concat(
-                    [
-                    pd.DataFrame([dvh_metrics | {"name":dir_plan.name}]),
-                    all_dvhs
-                    ],
-                ignore_index=True
-                )
-            
-        except Exception as e:
-            print(f"error in getting dvh for {dir_plan}")
-            print(e)
-    all_dvhs.set_index("name", inplace=True)
-    all_dvhs.to_csv(dir_all_plan_folders/"dvh_metrics.csv")
+    all_dvhs = pd.DataFrame(columns=list(dvh_metric_goals.keys()))
+    for dir_plan in dosimetry_inputs:
+        print(f"dvh from dicom folder: {dir_plan.get('pth_phant')}")
+        # try:
+        dvh_metrics = get_dvh_metrics_single_plan(
+            dir_dicom=dir_plan.get('pth_phant'),
+            dvh_metric_goals=dvh_metric_goals,
+            load_dose_from=dir_plan.get('pth_dose'),
+            dir_dose_rate=dir_plan.get('dir_dose_rate', None),
+            export_combined_dose=False,
+            prescription_dose=prescription_dose
+        )
 
-def run_get_dvh_metrics_all_plans():
-    # # on alien baby
-    # pth_all_dicom = Path("/root/YourLocalHome/Data/prostate/prostate-glen-2023")
-    # dir_all_plans = Path("/root/YourLocalHome/Data/prostate/plans-1mm/prostate-glen-2023")
-    # # on photon
-    pth_all_dicom = Path("/root/YourLocalHome/Data/prostate-glen-2023")
-    dir_all_plans = Path("temp_data/tg43/prostate-glen-2023")
-    dvh_metric_goals = {
-        "D95%(ctv)": 15,
-        "D1cc(rectum)": 11.25,
-        "D0.1cc(urethra)": 18.75,
-    }
-    get_dvh_metrics_all_plans(
-        dir_all_dicom_folders=pth_all_dicom,
-        dir_all_plan_folders=dir_all_plans,
-        dvh_metric_goals=dvh_metric_goals,
-    )
+        # except Exception as e:
+        #     print(f"error in getting dvh for {dir_plan}")
+        #     print(e)
+    all_dvhs.set_index("name", inplace=True)
+    all_dvhs.to_csv(pth_out_csv)
 
 def test_get_dvh_metrics_single_plan():
     pth_single_dicom = Path("/root/YourLocalHome/Data/prostate-glen-2023/p2")
@@ -421,6 +400,12 @@ def gen_dosimetry_inputs(
     to load phantoms (image + segementation) and combined doses of multiple patients
     into a list of dictionaries, where the keys are patient number and the values are the 
     paths.
+    ### Inputs:
+    - dir_phantoms:= directory, where the folders containing phantom files of each patient is located.
+    - dir_doses:= directory, where the folders containing the dose file of each patient is located.
+    the names of the dose directories must match the name of the phantom directory.
+    ### Outputs:
+    - 
     """
     list_phnatoms = list(Path(dir_phnatoms).glob("*/"))
     list_doses = list(Path(dir_doses).glob("*/*combined.seq.nrrd"))
@@ -451,6 +436,17 @@ if __name__ == "__main__":
     dir_all_dicoms = Path("/home/ubuntu").joinpath("YourLocalHome/Data/prostate/prostate-glen-2023")
     dir_export_tg43 = Path("temp_data/tg43/prostate-glen-2023") # for tg43
     dir_export_mc = Path("temp_data/mc/prostate-glen-2023") # for Monte Carlo
+    dvh_metric_goals = {
+        "V100%(ctv)": 95,
+        "D90%(ctv)": 15,
+        "V150%(ctv)": 40,
+        "HI(ctv)": 1,
+        "CI(ctv)": 1,
+        "D2cc(rectum)": 10,
+        "D10%(urethra)":17,
+        "D30%(urethra)": 15,
+    }
+    prescription_dose = 15 # in Gy
 
     # export all dicoms to plans
     # for dir_export in [dir_export_tg43, dir_export_mc]:
@@ -474,5 +470,10 @@ if __name__ == "__main__":
         dir_doses=dir_export_tg43,
         # dir_doses = dir_export_mc,
     )
-    run_get_dvh_metrics_all_plans()
+    get_dvh_metrics_all_plans(
+        dosimetry_inputs=dosimetry_inputs,
+        dvh_metric_goals=dvh_metric_goals,
+        pth_out_csv=dir_export_tg43,
+        prescription_dose=prescription_dose
+    )
     # run_scale_by_airkerma()

--- a/examples/benchmarks/eval_dose_generation.py
+++ b/examples/benchmarks/eval_dose_generation.py
@@ -5,6 +5,7 @@ from brachyutils import load_dicom_to_plan
 from brachyutils import DoseMonteCarlo, DoseTG43
 import pandas as pd
 from time import time
+import numpy as np
 
 def run_multi_proc(function, input_list, max_workers=8):
     from multiprocessing import Pool
@@ -256,16 +257,20 @@ def get_dvh_metrics_all_plans(
     all_dvhs = pd.DataFrame(columns=list(dvh_metric_goals.keys())+["plan_id"])
     for dir_plan in tqdm(dosimetry_inputs):
         print(f"dvh from dicom folder: {dir_plan.get('pth_phant')}")
-        dvh_metrics = get_dvh_metrics_single_plan(
-            dir_dicom=dir_plan.get('pth_phant'),
-            dvh_metric_goals=dvh_metric_goals,
-            load_dose_from=dir_plan.get('pth_dose'),
-            dir_dose_rate=dir_plan.get('dir_dose_rate', None),
-            export_combined_dose=False,
-            prescription_dose=prescription_dose
-        )
-        all_dvhs.loc[len(all_dvhs)] = {"plan_id": dir_plan.get('plan_id')} | dvh_metrics
-
+        try:
+            dvh_metrics = get_dvh_metrics_single_plan(
+                dir_dicom=dir_plan.get('pth_phant'),
+                dvh_metric_goals=dvh_metric_goals,
+                load_dose_from=dir_plan.get('pth_dose'),
+                dir_dose_rate=dir_plan.get('dir_dose_rate', None),
+                export_combined_dose=False,
+                prescription_dose=prescription_dose
+            )
+            all_dvhs.loc[len(all_dvhs)] = {"plan_id": dir_plan.get('plan_id')} | dvh_metrics
+        except Exception as e:
+            print(f"Error processing plan {dir_plan.get('plan_id')}: {e}")
+            all_dvhs.loc[len(all_dvhs)] = {"plan_id": dir_plan.get('plan_id')} | {key: np.nan for key in dvh_metric_goals.keys()}
+            continue
     all_dvhs.to_csv(pth_out_csv, index=False)
 
 def test_get_dvh_metrics_single_plan():
@@ -396,7 +401,8 @@ def run_scale_by_airkerma():
 
 def gen_dosimetry_inputs(
     dir_phnatoms: str | Path,
-    dir_doses: str | Path
+    dir_doses: str | Path,
+    dose_format: Literal["nrrd", "3ddose", "dicom"] = "nrrd",
 ):
     r"""
     ### Purpose:
@@ -411,14 +417,21 @@ def gen_dosimetry_inputs(
     - 
     """
     list_phnatoms = list(Path(dir_phnatoms).glob("*/"))
-    list_doses = list(Path(dir_doses).glob("*/*combined.seq.nrrd"))
-    
+    if dose_format == "nrrd":
+        list_doses = list(Path(dir_doses).glob("*/*combined.seq.nrrd"))
+    elif dose_format == "3ddose":
+        list_doses = list(Path(dir_doses).glob("*/*combined.3ddose"))
+    elif dose_format == "dicom":
+        list_doses = list(Path(dir_doses).glob("*/RD*.dcm"))
+    else:
+        raise ValueError(f"Invalid dose_format: {dose_format}. Valid formats are 'nrrd', '3ddose' and 'dicom'.")
+
     plan_inputs_list = []
     for dir_phant in list_phnatoms:
         # find the right dose file
         for dose_file in list_doses:
             if dose_file.parent.name == dir_phant.name:
-                pth_dose = dose_file
+                pth_dose = dose_file if dose_format != "dicom" else "dicom"
                 break
 
         plan_inputs_list.append(
@@ -469,10 +482,15 @@ if __name__ == "__main__":
     #     method="mc"
     # )
     
-    for dir_export in [dir_export_tg43, dir_export_mc]:
+    for dir_export in [
+        dir_export_tg43,
+        dir_export_mc,
+        dir_all_dicoms
+        ]:
         dosimetry_inputs = gen_dosimetry_inputs(
             dir_phnatoms=dir_all_dicoms,
             dir_doses=dir_export,
+            dose_format="nrrd" if dir_export != dir_all_dicoms else "dicom"
         )
         get_dvh_metrics_all_plans(
             dosimetry_inputs=dosimetry_inputs,

--- a/examples/benchmarks/eval_dose_generation.py
+++ b/examples/benchmarks/eval_dose_generation.py
@@ -462,7 +462,7 @@ def gen_box_plots_dvh_timing(
         data_mc[["V100%(ctv)", "V150%(ctv)"]],
         title = "TG43 vs MC DVH Metrics",
         xlabel = "DVH Metrics",
-        ylabel = "Volume Percentage [%]",
+        ylabel = "Percentage of Target Volume [%]",
         fig_size=(6, 4),
         alpha_tg43=0.5,
         alpha_mc=1.0,
@@ -470,6 +470,36 @@ def gen_box_plots_dvh_timing(
         font_size=14,
         legend_loc="upper right",
         save_path=pth_dvh_csv_tg43.parent.parent.parent/"boxplot_mc_tg43_Vx.svg"
+    )
+    # generate the box plots for D90%, D10%, D30%, D2cc
+    boxplot_tg43_mc(
+        data_tg43[["D90%(ctv)", "D10%(urethra)", "D30%(urethra)", "D2cc(rectum)"]],
+        data_mc[["D90%(ctv)", "D10%(urethra)", "D30%(urethra)", "D2cc(rectum)"]],
+        title = "TG43 vs MC DVH Metrics",
+        xlabel = "DVH Metrics",
+        ylabel = "Percentage of Prescription Dose [%]",
+        fig_size=(12, 8),
+        alpha_tg43=0.5,
+        alpha_mc=1.0,
+        box_color=(0.70,0.52,0.75),
+        font_size=14,
+        legend_loc="upper right",
+        save_path=pth_dvh_csv_tg43.parent.parent.parent/"boxplot_mc_tg43_Dx.svg"
+    )
+    # Generate box plots for dose generation timing
+    boxplot_tg43_mc(
+        data_tg43[["dose_generation_time"]],
+        data_mc[["dose_generation_time"]],
+        title = "TG43 vs MC Dose Generation Timing",
+        xlabel = "Dose Generation Method",
+        ylabel = "Time [s]",
+        fig_size=(6, 4),
+        alpha_tg43=0.5,
+        alpha_mc=1.0,
+        box_color=(0.36,0.54,0.66),
+        font_size=14,
+        legend_loc="upper right",
+        save_path=pth_dvh_csv_tg43.parent.parent.parent/"boxplot_mc_tg43_timing.svg"
     )
 
 def boxplot_tg43_mc(

--- a/examples/benchmarks/eval_dose_generation.py
+++ b/examples/benchmarks/eval_dose_generation.py
@@ -6,6 +6,7 @@ from brachyutils import DoseMonteCarlo, DoseTG43
 import pandas as pd
 from time import time
 import numpy as np
+import matplotlib.pyplot as plt
 
 def run_multi_proc(function, input_list, max_workers=8):
     from multiprocessing import Pool
@@ -448,9 +449,133 @@ def gen_box_plots_dvh_timing(
     timing_tg43 = pd.read_csv(pth_timing_csv_tg43)
     timing_mc = pd.read_csv(pth_timing_csv_mc)
     
-    # merge dvh data with timing data
-    data_tg43 = 
+    # merge dvh data with timing data based on plan_id
+    # data_tg43 = data_tg43.merge(timing_tg43, on="plan_id")
+    # data_mc = data_mc.merge(timing_mc, on="plan_id")
+    
+    data_tg43.to_csv(pth_dvh_csv_tg43.parent/"dose_generation_data_tg43.csv", index=False)
+    data_mc.to_csv(pth_dvh_csv_mc.parent/"dose_generation_data_mc.csv", index=False)
+    
+    # generate the box plots then
+    boxplot_tg43_mc(
+        data_tg43,
+        data_mc,
+        title = "DVH Metrics from RapidBrachy TG43 vs Monte Carlo Dose Calculation",
+        xlabel = "DVH Metrics",
+        ylabel = " Value [%]",
+        fig_size=(12, 8),
+        alpha_tg43=0.5,
+        alpha_mc=1.0,
+        box_color=(0.2, 0.4, 0.6),
+        font_size=16,
+        save_path=pth_dvh_csv_tg43.parent/"dose_generation_comparison_boxplots.svg"
+    )
 
+def boxplot_tg43_mc(
+    df_tg43: pd.DataFrame,
+    df_mc: pd.DataFrame,
+    title: str = "TG43 vs MC Boxplots",
+    xlabel: str = "Metrics",
+    ylabel: str = "Values",
+    fig_size=(10, 6),
+    alpha_tg43=0.5,
+    alpha_mc=1.0,
+    box_color=(0, 0, 0),
+    font_size=14,
+    save_path: Path | str = None,
+):
+    """
+    General boxplot comparison function for TG43 and MC dose evaluation metrics.
+
+    Each column becomes a tick label, and TG43/MC appear side by side.
+
+    Parameters
+    ----------
+    df_tg43 : pd.DataFrame
+        TG43 dataset with numerical columns.
+    df_mc : pd.DataFrame
+        MC dataset with numerical columns.
+    title : str
+        Plot title.
+    xlabel, ylabel : str
+        Axis labels.
+    fig_size : tuple
+        Figure dimensions.
+    alpha_tg43 : float
+        Transparency for TG43 boxes.
+    alpha_mc : float
+        Transparency for MC boxes.
+    box_color : tuple
+        RGB color of boxes.
+    font_size : int
+        Font size for labels.
+    save_path : Path or str, optional
+        If provided, saves the plot instead of showing it.
+    """
+
+    plt.rcParams.update({"font.size": font_size})
+    plt.rcParams["figure.dpi"] = 300
+
+    # drop non-numeric columns
+    df_tg43 = df_tg43.select_dtypes(include=np.number)
+    df_mc = df_mc.select_dtypes(include=np.number)
+
+    columns = df_tg43.columns.intersection(df_mc.columns)
+    n_cols = len(columns)
+
+    fig, ax = plt.subplots(figsize=fig_size)
+    box_width = 0.35
+    x_positions = np.arange(n_cols)
+
+    # compute side-by-side positions
+    tg43_positions = x_positions - box_width / 2
+    mc_positions = x_positions + box_width / 2
+
+    bp_tg43 = ax.boxplot(
+        [df_tg43[col].dropna() for col in columns],
+        positions=tg43_positions,
+        widths=box_width,
+        patch_artist=True,
+    )
+
+    bp_mc = ax.boxplot(
+        [df_mc[col].dropna() for col in columns],
+        positions=mc_positions,
+        widths=box_width,
+        patch_artist=True,
+    )
+
+    # appearance
+    for patch in bp_tg43["boxes"]:
+        patch.set_facecolor(box_color)
+        patch.set_alpha(alpha_tg43)
+
+    for patch in bp_mc["boxes"]:
+        patch.set_facecolor(box_color)
+        patch.set_alpha(alpha_mc)
+
+    ax.set_xticks(x_positions)
+    ax.set_xticklabels(columns, rotation=45, ha="right")
+    ax.set_xlabel(xlabel)
+    ax.set_ylabel(ylabel)
+    ax.set_title(title)
+    ax.grid(True, alpha=0.3)
+
+    from matplotlib.patches import Patch
+    legend_elements = [
+        Patch(facecolor=box_color, alpha=alpha_tg43, label="TG43"),
+        Patch(facecolor=box_color, alpha=alpha_mc, label="MC"),
+    ]
+    ax.legend(handles=legend_elements, loc="upper left", fontsize=font_size - 2)
+
+    plt.tight_layout()
+    if save_path:
+        plt.savefig(save_path, dpi=300)
+    else:
+        plt.show()
+    plt.close()
+
+   
 if __name__ == "__main__":
     # test_export()
     # test_dose_calc()
@@ -521,6 +646,6 @@ if __name__ == "__main__":
     gen_box_plots_dvh_timing(
         pth_dvh_csv_tg43=dir_export_tg43/"dose_generation_dvh.csv",
         pth_dvh_csv_mc=dir_export_mc/"dose_generation_dvh.csv",
-        pth_timing_csv_tg43=dir_export_tg43/"dose_generation_time.csv",
-        pth_timing_csv_mc=dir_export_mc/"dose_generation_time.csv",
+        pth_timing_csv_tg43=dir_export_tg43/"dose_generation_timing.csv",
+        pth_timing_csv_mc=dir_export_mc/"dose_generation_timing.csv",
     )

--- a/examples/benchmarks/eval_dose_generation.py
+++ b/examples/benchmarks/eval_dose_generation.py
@@ -642,13 +642,20 @@ def gen_percent_error_maps(
             dose1=dose_mc,
             dose2=dose_tg43,
             compute_percent_difference=True,
+            prescription_dose=21.,
             compute_gamma_index=False,
             positive_percent_difference=False,
         )
-        # dose_comp.plot_local_and_global_differences(
-        #     axis_1_coords=
-        # )
-    
+        vox_centers = dose_mc.get_voxel_centers()
+        dose_comp.plot_local_and_global_differences(
+            axis_1_coords=vox_centers[0],
+            axis_2_coords=vox_centers[1],
+            plane_coord=vox_centers[2][len(vox_centers[2])//2],
+            plane="xy",
+            plot_titles=(f"MC vs TG43 Percent Error Map for Plan {plan_id}"),
+            pth_fig_save=Path(dir_output)/f"percent_error_map_{plan_id}.svg"
+        )
+        break; # for debugging
 
 if __name__ == "__main__":
     # test_export()
@@ -717,26 +724,26 @@ if __name__ == "__main__":
     #         prescription_dose=prescription_dose
     #     )
 
-    gen_box_plots_dvh_timing(
-        pth_dvh_csv_tg43=dir_export_tg43/"dose_generation_dvh.csv",
-        pth_dvh_csv_mc=dir_export_mc/"dose_generation_dvh.csv",
-        pth_timing_csv_tg43=dir_export_tg43/"dose_generation_timing.csv",
-        pth_timing_csv_mc=dir_export_mc/"dose_generation_timing.csv",
+    # gen_box_plots_dvh_timing(
+    #     pth_dvh_csv_tg43=dir_export_tg43/"dose_generation_dvh.csv",
+    #     pth_dvh_csv_mc=dir_export_mc/"dose_generation_dvh.csv",
+    #     pth_timing_csv_tg43=dir_export_tg43/"dose_generation_timing.csv",
+    #     pth_timing_csv_mc=dir_export_mc/"dose_generation_timing.csv",
+    # )
+
+    dosimetry_inputs_tg43 = gen_dosimetry_inputs(
+        dir_phnatoms=dir_all_dicoms,
+        dir_doses=dir_export_tg43,
+        dose_format="nrrd"
     )
 
-    # dosimetry_inputs_tg43 = gen_dosimetry_inputs(
-    #     dir_phnatoms=dir_all_dicoms,
-    #     dir_doses=dir_export_tg43,
-    #     dose_format="nrrd"
-    # )
-
-    # dosimetry_inputs_mc = gen_dosimetry_inputs(
-    #     dir_phnatoms=dir_all_dicoms,
-    #     dir_doses=dir_export_mc,
-    #     dose_format="nrrd"
-    # )
-    # gen_percent_error_maps(
-    #     dosimetry_inputs_mc=dosimetry_inputs_mc,
-    #     dosimetry_inputs_tg43=dosimetry_inputs_tg43,
-    #     dir_output=Path("temp_data")
-    # )
+    dosimetry_inputs_mc = gen_dosimetry_inputs(
+        dir_phnatoms=dir_all_dicoms,
+        dir_doses=dir_export_mc,
+        dose_format="nrrd"
+    )
+    gen_percent_error_maps(
+        dosimetry_inputs_mc=dosimetry_inputs_mc,
+        dosimetry_inputs_tg43=dosimetry_inputs_tg43,
+        dir_output=Path("temp_data")
+    )

--- a/examples/benchmarks/eval_dose_generation.py
+++ b/examples/benchmarks/eval_dose_generation.py
@@ -595,8 +595,8 @@ def boxplot_tg43_mc(
 
     from matplotlib.patches import Patch
     legend_elements = [
-        Patch(facecolor=box_color, alpha=alpha_tg43, label="TG43"),
-        Patch(facecolor=box_color, alpha=alpha_mc, label="MC"),
+        Patch(facecolor=box_color, alpha=alpha_tg43, label="RapidBrachy-TG43"),
+        Patch(facecolor=box_color, alpha=alpha_mc, label="RapidBrachy-MC"),
     ]
     ax.legend(handles=legend_elements, loc=legend_loc, fontsize=font_size - 2)
 
@@ -607,7 +607,49 @@ def boxplot_tg43_mc(
         plt.show()
     plt.close()
 
-   
+def gen_percent_error_maps(
+    dosimetry_inputs_mc: list[Dict[str, Union[str, Path]]],
+    dosimetry_inputs_tg43: list[Dict[str, Union[str, Path]]],
+    dir_output: Path | str,
+):
+    r"""
+    ### Purpose: To generate percent error maps and histograms between MC and TG43 
+    dose distributions for all plans.
+    ### Inputs:
+    - dosimetry_inputs_mc:= list of dictionaries, where each dictionary contains the following
+        keys:
+        - plan_id:= str, the patient id
+        - pth_phant:= Path, the path to the phantom directory
+        - pth_dose:= Path, the path to the dose file
+    - dosimetry_inputs_tg43:= Same as dosimetry_inputs_mc but for TG43 doses.
+    - dir_output:= Path | str, the directory to save the percent error maps and histograms.
+    ### Outputs:
+        - Saves percent error maps and histograms in dir_output.
+    """
+    from brachyutils import BrachyDose
+    from brachyutils import BrachyDoseComparison
+
+    for dosi_input in dosimetry_inputs_mc:
+        plan_id = dosi_input.get("plan_id")
+        # find corresponding tg43 input
+        tg43_input = next((item for item in dosimetry_inputs_tg43 if item["plan_id"] == plan_id), None)
+        if tg43_input is None:
+            print(f"No TG43 data found for plan {plan_id}, skipping.")
+            continue
+        dose_mc = BrachyDose(dosi_input.get("pth_dose"))
+        dose_tg43 = BrachyDose(tg43_input.get("pth_dose"))
+        dose_comp = BrachyDoseComparison(
+            dose1=dose_mc,
+            dose2=dose_tg43,
+            compute_percent_difference=True,
+            compute_gamma_index=False,
+            positive_percent_difference=False,
+        )
+        # dose_comp.plot_local_and_global_differences(
+        #     axis_1_coords=
+        # )
+    
+
 if __name__ == "__main__":
     # test_export()
     # test_dose_calc()
@@ -681,3 +723,20 @@ if __name__ == "__main__":
         pth_timing_csv_tg43=dir_export_tg43/"dose_generation_timing.csv",
         pth_timing_csv_mc=dir_export_mc/"dose_generation_timing.csv",
     )
+
+    # dosimetry_inputs_tg43 = gen_dosimetry_inputs(
+    #     dir_phnatoms=dir_all_dicoms,
+    #     dir_doses=dir_export_tg43,
+    #     dose_format="nrrd"
+    # )
+
+    # dosimetry_inputs_mc = gen_dosimetry_inputs(
+    #     dir_phnatoms=dir_all_dicoms,
+    #     dir_doses=dir_export_mc,
+    #     dose_format="nrrd"
+    # )
+    # gen_percent_error_maps(
+    #     dosimetry_inputs_mc=dosimetry_inputs_mc,
+    #     dosimetry_inputs_tg43=dosimetry_inputs_tg43,
+    #     dir_output=Path("temp_data")
+    # )

--- a/examples/benchmarks/eval_dose_generation.py
+++ b/examples/benchmarks/eval_dose_generation.py
@@ -126,6 +126,8 @@ def run_dose_generation(
                 "dose_gen_method": "tg43",
                 "dose_generation_time": t1 - t0
             }
+            # break # for debugging
+    # # for Monte Carlo
     elif method == "mc":
         dir_plans = list(dir_plan_export.glob("*/"))
         for plan in tqdm(dir_plans):
@@ -418,13 +420,17 @@ if __name__ == "__main__":
     dir_all_dicoms = Path("/home/ubuntu").joinpath("YourLocalHome/Data/prostate/prostate-glen-2023")
     dir_export_tg43 = Path("temp_data/tg43/prostate-glen-2023") # for tg43
     dir_export_mc = Path("temp_data/mc/prostate-glen-2023") # for Monte Carlo
-    for dir_export in [dir_export_tg43, dir_export_mc]:
-        run_export(
-            dir_all_dicoms=dir_all_dicoms,
-            dir_export=dir_export,
-            multi_proc=False,
-        )
+
+    # # export all dicoms to plans
+    # for dir_export in [dir_export_tg43, dir_export_mc]:
+    #     run_export(
+    #         dir_all_dicoms=dir_all_dicoms,
+    #         dir_export=dir_export,
+    #         multi_proc=False,
+    #     )
         # break
+
+    # # run dose generation for all plans
     run_dose_generation(
         dir_plan_export=dir_export_tg43,
         method="tg43"

--- a/examples/benchmarks/eval_dose_generation.py
+++ b/examples/benchmarks/eval_dose_generation.py
@@ -112,7 +112,7 @@ def run_dose_generation(
     method: Literal["tg43", "mc"] = "tg43",
 ):
     timing_data = pd.DataFrame(columns=[
-        "plan_name", "dose_gen_method", "dose_generation_time"
+        "plan_id", "dose_gen_method", "dose_generation_time"
         ])
     # # for TG43
     if method == "tg43":
@@ -123,7 +123,7 @@ def run_dose_generation(
             run_single_tg43_dose_generation(plan)
             t1 = time()
             timing_data.loc[len(timing_data)] = {
-                "plan_name": plan.name,
+                "plan_id": plan.name,
                 "dose_gen_method": "tg43",
                 "dose_generation_time": t1 - t0
             }
@@ -137,7 +137,7 @@ def run_dose_generation(
             run_single_mc_dose_generation(plan)
             t1 = time()
             timing_data.loc[len(timing_data)] = {
-                "plan_name": plan.name,
+                "plan_id": plan.name,
                 "dose_gen_method": "mc",
                 "dose_generation_time": t1 - t0
             }
@@ -443,7 +443,13 @@ def gen_box_plots_dvh_timing(
     pth_timing_csv_tg43: Path | str,
     pth_timing_csv_mc: Path | str,
 ):
-    pass
+    data_tg43 = pd.read_csv(pth_dvh_csv_tg43)
+    data_mc = pd.read_csv(pth_dvh_csv_mc)
+    timing_tg43 = pd.read_csv(pth_timing_csv_tg43)
+    timing_mc = pd.read_csv(pth_timing_csv_mc)
+    
+    # merge dvh data with timing data
+    data_tg43 = 
 
 if __name__ == "__main__":
     # test_export()

--- a/examples/benchmarks/eval_dose_generation.py
+++ b/examples/benchmarks/eval_dose_generation.py
@@ -163,7 +163,8 @@ def get_dvh_metrics_single_plan(
     load_dose_from: Literal["dicom"] | Path | str = "dicom",
     dir_dose_rate: Path | str = None,
     export_combined_dose: bool = True,
-
+    delivered_catheter_table: bool = True,
+    strict_name_match: bool = False,
 ) -> Dict[str, float]:
     r"""
     ### Purpose:
@@ -185,6 +186,8 @@ def get_dvh_metrics_single_plan(
             dvh_metric_goals=dvh_metric_goals,
             combined_dose_only=True,
             prescription_dose=prescription_dose,
+            delivered_catheter_table=delivered_catheter_table,
+            strict_name_match=strict_name_match
             )
     elif isinstance(load_dose_from, str) or isinstance(load_dose_from, Path):
         load_dose_from = Path(load_dose_from)
@@ -196,7 +199,9 @@ def get_dvh_metrics_single_plan(
                 prescription_dose=prescription_dose,
                 combined_dose=load_dose_from,
                 combined_dose_only=True,
-                multi_processing=True
+                multi_processing=True,
+                delivered_catheter_table=delivered_catheter_table,
+                strict_name_match=strict_name_match,
                 )
         elif load_dose_from.is_dir():
             plan_obj = load_dicom_to_plan(
@@ -206,7 +211,9 @@ def get_dvh_metrics_single_plan(
             prescription_dose=prescription_dose,
             dir_dose_rate=dir_dose_rate,
             combined_dose_only=True,
-            multi_processing=True
+            multi_processing=True,
+            delivered_catheter_table=delivered_catheter_table,
+            strict_name_match=strict_name_match,
             )
         else:
             raise ValueError(f"Invalid load_dose_from: {load_dose_from}\

--- a/examples/benchmarks/eval_registration.py
+++ b/examples/benchmarks/eval_registration.py
@@ -137,7 +137,6 @@ def evaluate_registration(
             "hausdorff(Biopsies)": eval_results.get("hausdorff(Biopsies)"),
             "time": eval_results.get("time")
         }
-        # XXX for debugging
         # break
     out_file_name = "reg_metrics_"+ dir_registered.parent.name +"_"+ dir_registered.name+".csv"
     results_per_case_df.to_csv(dir_registered.parent.parent/out_file_name)
@@ -307,7 +306,6 @@ def eval_reg_plastimatch(
                 "num_failed": reg_results.get("num_failed")
             }
             results_df.to_csv(dir_registered/"registration_results_plastimatch.csv", index=False)
-            # break #XXX only do one for now
 
 def eval_reg_simple_elastix(
     reg_data_inputs: List[Dict[str, Union[str, Path]]],


### PR DESCRIPTION
Compared the dose generation using RapidBrachyMC vs RapidBrachyTG43.
Along the way, the following were done:
1. resampling for egsphant.
2. fixed a bug with contour downsampling on open tps
3. allowing plans to load structures without strict name matching (ctv vs ctv_brachy would be the same)
4. dose comparison takes figure size and title font size as a parameter. in addition, the figure could be saved without using gui.