### PR TITLE
small updates to the example script for Hecktor challenge. the dose data from the challenge is messed up.

### DIFF
--- a/examples/hecktor25_dose_extraction.py
+++ b/examples/hecktor25_dose_extraction.py
@@ -18,7 +18,7 @@ if __name__ == "__main__":
     phantom_obj_static = BrachyPhantom(
         pth_phantom_file=pth_ct_static,
     )
-    # # for debugging
+    # for debugging {
     phantom_obj_static.export_to(dir_nrrd_out=dir_test_export)
     exported_phantom = BrachyPhantom(
         pth_phantom_file=dir_test_export / (dir_hecktor_nifti.name + "__PlanningCT.nrrd")
@@ -30,32 +30,42 @@ if __name__ == "__main__":
         pth_phantom_file=pth_ct_moving,
         pth_structures_file=pth_seg_moving,
     )
-    # # for debugging {
+    # for debugging {
     phantom_obj_moving.export_to(
         dir_nrrd_out=dir_test_export
         )
     # }
-    # exported_phantom_moving = BrachyPhantom(
+    
+    # # # crop the static phantom to match the coordinates of moving phantom grid
+    # from opentps.core.processing.imageProcessing.resampler3D import crop3DDataAroundBox
+    # phantom_obj_moving.image_obj.getPositionFromVoxelIndex()
+    # # # for debugging {
+    # phantom_obj_moving.export_to(
+    #     dir_nrrd_out=dir_test_export/"phantom_moving_resampled"
+    #     )
+    # # # }
+
     # reg_obj = Registration_OpenTPS(
     #     static_phantom=phantom_obj_static,
     #     moving_phantom=phantom_obj_moving,
     # )
-    # phantom_registered = reg_obj.register()
+    # phantom_registered, _ = reg_obj.register()
     # # # for debugging {
     # phantom_registered.export_to(dir_nrrd_out=dir_test_export/"phantom_registered")
-    # }
+    # print("debug here")
+    # # }
 
     # # load the dose file
-    dose_obj = BrachyDose(
-        pth_dose_file=pth_dose_static,
-    )
-    # # for debugging{
-    dose_obj.write_brachydose_to_file(
-        pth_dose_file=dir_test_export/"dose.seq.nrrd"
-        )
-    test_dose_obj = BrachyDose(
-        pth_dose_file=dir_test_export/"dose.seq.nrrd"
-    )
+    # dose_obj = BrachyDose(
+    #     pth_dose_file=pth_dose_static,
+    # )
+    # # # for debugging{
+    # dose_obj.write_brachydose_to_file(
+    #     pth_dose_file=dir_test_export/"dose.seq.nrrd"
+    #     )
+    # test_dose_obj = BrachyDose(
+    #     pth_dose_file=dir_test_export/"dose.seq.nrrd"
+    # )
     # # }
     # # create a plan from phantom and dose
     # plan_obj = BrachyPlan(


### PR DESCRIPTION
realized that the CT and CT-planning do not overlap in physical space. fixing this is not worth it for the small number of CT-planning samples at Hecktor.

I have made sure that the loading of image coordinates in BrachyUtils matches that of 3DSlicer.

Then, I tried to register the CT contours to the CT-planning image such that we can get DVH metrics from the dose generated based on CT-planning.

however, registration failed and empty images were generated.

i wanted to make sure that both scans (CT and CT-planning) are in the same coordinate system. So i looked at the physical extent on the x, y and z axis. They are not in the same coordinate system! At least the PET scans can be cropped to match the coordinates on the CT. but CT-planning is just wayyy out of the picture (especially on z axis)

CT-planning
xlims: -300 to 298
ylims: -370 to 227
zlims: -10 to 507

CT
xlims: -124 to 124.75 
ylims: 30.24 to 279.75
zlims: -359 to -13

PET
xlims: -408 to 402
ylims: -249 to 562
zlims: -359 to -13

not sure how to proceed from here to be honest. we need contours on CT-planning on get the DVH metrics.