### PR TITLE
Merge contour_to_stl into main

### DIFF
--- a/brachyutils/geometry/__init__.py
+++ b/brachyutils/geometry/__init__.py
@@ -8,9 +8,11 @@ __all__ = [
     "Catheter",
     "CatheterTable",
     "get_uniform_phantom",
+    "contour_to_stl",
 ]
 # trunk-ignore(ruff/F401)
-from .phantom_utils import BrachyPhantom, get_uniform_phantom
+from .phantom_utils import BrachyPhantom
+from .phantom_utils import get_uniform_phantom, contour_to_stl
 
 # trunk-ignore(ruff/F401)
 from .egsphant_utils import BrachyEgsphant

--- a/brachyutils/geometry/__init__.py
+++ b/brachyutils/geometry/__init__.py
@@ -9,10 +9,11 @@ __all__ = [
     "CatheterTable",
     "get_uniform_phantom",
     "contour_to_stl",
+    "mask_to_stl",
 ]
 # trunk-ignore(ruff/F401)
 from .phantom_utils import BrachyPhantom
-from .phantom_utils import get_uniform_phantom, contour_to_stl
+from .phantom_utils import get_uniform_phantom, contour_to_stl, mask_to_stl
 
 # trunk-ignore(ruff/F401)
 from .egsphant_utils import BrachyEgsphant

--- a/brachyutils/geometry/egsphant_utils.py
+++ b/brachyutils/geometry/egsphant_utils.py
@@ -591,7 +591,7 @@ class BrachyEgsphant:
             [0.0, self.density_image.spacing[1], 0.0],
             [0.0, 0.0, self.density_image.spacing[2]],
         ]
-        header["kinds"] = ["2-vector", "space", "space", "space"]
+        header["kinds"] = ["list", "space", "space", "space"]
         header["labels"] = ["", "x", "y", "z"]
         header["endian"] = "little"
         header["encoding"] = "gzip"

--- a/brachyutils/geometry/egsphant_utils.py
+++ b/brachyutils/geometry/egsphant_utils.py
@@ -584,11 +584,18 @@ class BrachyEgsphant:
         header["space origin"] = self.density_image.origin.tolist()
         header["spacing"] = [np.nan] + self.density_image.spacing.tolist()
         
+        # each voxel in the material matrix is encoded with a single character
+            # from this array that represents a unique material recognized by RapidBrachyMC.
+        #have to redefine here since nrrd egsphants start at 0
+        BrachyEgsphant._materials_encoding_array = [str(i) for i in range(0, 10)] + [
+            chr(i) for i in range(ord("A"), ord("Z") + 1)
+        ]
+
         header = header | {
             "material_dict": {
             material: {
                 "encoding": BrachyEgsphant._materials_encoding_array.index(
-                    self.material_dict[material].get("encoding")
+                    str(self.material_dict[material].get("encoding"))
                 ),
                 "density": float(self.material_dict.get(material).get("density")),
                 "HU_limit": (

--- a/brachyutils/geometry/egsphant_utils.py
+++ b/brachyutils/geometry/egsphant_utils.py
@@ -415,8 +415,7 @@ class BrachyEgsphant:
         self.voxel_edges = np.empty(len(voxel_centers), dtype=object)
         for i in range(len(voxel_centers)):
             self.voxel_edges[i] = (
-                np.round(voxel_centers[i], decimals=1) -
-                np.round(self.density_image.spacing[i] / 2.0, decimals=1)
+               voxel_centers[i] - self.density_image.spacing[i] / 2.0
             )
 
         return self.voxel_edges
@@ -484,10 +483,14 @@ class BrachyEgsphant:
             os.path.splitext(fileName)[-1] == ".egsphant"
         ), "file extension is not .egsphant"
         Path.mkdir(fileName.parent, exist_ok=True, parents=True)
+
+        #auto select precision for egsphant
+        precision = 3 if self.density_image.spacing.min() > 0.1 else 5
+
         egsphant_voxel_edges = np.array(
             [
                 np.char.mod(
-                    "%.3f",
+                    f"%.{precision}f",
                     np.append(axis, axis[-1] + self.density_image.spacing[i]) / 10,
                     # axis / 10,
                 )

--- a/brachyutils/geometry/egsphant_utils.py
+++ b/brachyutils/geometry/egsphant_utils.py
@@ -281,10 +281,12 @@ class BrachyEgsphant:
             self.unit_length = "mm"
             # Extract material density from the density matrix and update the material dictionary
             for material in self.material_dict:
-                encoding = int(self.material_dict[material]["encoding"])
+                encoding_int = BrachyEgsphant._materials_encoding_array.index(
+                    self.material_dict[material]["encoding"]
+                )
                 density = np.unique(
                     self.density_image.imageArray[
-                        self.material_image.imageArray == encoding-1
+                        self.material_image.imageArray == encoding_int-1
                     ]
                 )
                 density = density.min() if len(density) != 0 else 0
@@ -601,7 +603,9 @@ class BrachyEgsphant:
         header = header | {
             "material_dict": {
             material: {
-                "encoding": int(self.material_dict.get(material).get("encoding")),
+                "encoding": BrachyEgsphant._materials_encoding_array.index(
+                    self.material_dict[material].get("encoding")
+                ),
                 "density": float(self.material_dict.get(material).get("density")),
                 "HU_limit": (
                 float(self.material_dict.get(material).get("HU_limit"))

--- a/brachyutils/geometry/egsphant_utils.py
+++ b/brachyutils/geometry/egsphant_utils.py
@@ -202,15 +202,15 @@ class BrachyEgsphant:
             self._sanity_axis = np.array(
                 [
                     np.array(
-                        [np.round(float(x), decimals=3) for x in egsphant.readline().strip().split()],
+                        [float(x) for x in egsphant.readline().strip().split()],
                         dtype=np.float32,
                     ),
                     np.array(
-                        [np.round(float(y), decimals=3) for y in egsphant.readline().strip().split()],
+                        [float(y) for y in egsphant.readline().strip().split()],
                         dtype=np.float32,
                     ),
                     np.array(
-                        [np.round(float(z), decimals=3) for z in egsphant.readline().strip().split()],
+                        [float(z) for z in egsphant.readline().strip().split()],
                         dtype=np.float32,
                     ),
                 ],
@@ -235,12 +235,11 @@ class BrachyEgsphant:
             origin = np.array(
                 [
                     self._sanity_axis[0][0] + spacing[0] / 2,
-                    self._sanity_axis[1][0] + spacing[0] / 2,
-                    self._sanity_axis[2][0] + spacing[0] / 2,
+                    self._sanity_axis[1][0] + spacing[1] / 2,
+                    self._sanity_axis[2][0] + spacing[2] / 2,
                 ],
                 dtype=np.float32,
             )
-
             # prepare empty matricies to hold material and density images
             material_matrix = np.zeros(
                 (gridSize[2], gridSize[1], gridSize[0]), dtype=str
@@ -503,27 +502,9 @@ class BrachyEgsphant:
         materials = "\n".join(self.material_dict.keys()) + "\n"
         spacing = "0 0 0 0 0 0 0 0 0\n"
         dimensions = " ".join(map(str, self.density_image.gridSize.astype(int))) + "\n"
-        x_axis = (
-            " ".join(
-                egsphant_voxel_edges[0]
-                # map(str, np.round(egsphant_voxel_edges[0].astype(float), decimals=3))
-            )
-            + "\n"
-        )
-        y_axis = (
-            " ".join(
-                egsphant_voxel_edges[1]
-                # map(str, np.round(egsphant_voxel_edges[1].astype(float), decimals=3))
-            )
-            + "\n"
-        )
-        z_axis = (
-            " ".join(
-                egsphant_voxel_edges[2]
-                # map(str, np.round(egsphant_voxel_edges[2].astype(float), decimals=3))
-            )
-            + "\n"
-        )
+        x_axis = (" ".join(egsphant_voxel_edges[0]) + "\n")
+        y_axis = (" ".join(egsphant_voxel_edges[1]) + "\n")
+        z_axis = (" ".join(egsphant_voxel_edges[2])+ "\n")
         material_matrix = self.get_material_array()
         material_matrix = _to_single_string(
             _convert_material_matrix_to(material_matrix, dtype=str), ""

--- a/brachyutils/geometry/phantom_utils.py
+++ b/brachyutils/geometry/phantom_utils.py
@@ -1854,151 +1854,116 @@ def contour_to_stl(roi_contour: ROIContour, pth_output: Path) -> None:
         - pth_output: Path := the path to save the STL file.
     Outputs:
         - None
-    Dependencies:
+    :
     """
-    #raise NotImplementedError("STL export of contours from ROIContour is not implement yet.")
-    #vertices, faces
-    if not isinstance(roi_contour, ROIContour):
-        raise ValueError("The input roi_contour should be an instance of ROIContour.")
-    structure_polygon_mesh = roi_contour.polygonMesh #each slice has a (1D) list of coordinates [x1, y1, z1, x2, y2, z2]
-    #structure coordinates into a single list of points (tuples)
-    points_list : List[List[float, float, float]] = []
-    for i_slice, slice_points in enumerate(structure_polygon_mesh):
-        if i_slice == 0 or i_slice == len(structure_polygon_mesh) - 1:
-            pass
-            ## Create vtkPoints object properly
-            
-            #polygon_points = vtk.vtkPoints()
-            
-            #slice_polygon = vtk.vtkPolygon()
-            
-            #
-            
-            #n_points = len(slice_points) // 3
-            
-            #for i in range(0, len(slice_points), 3):
-            
-            #    point = [slice_points[i], slice_points[i+1], slice_points[i+2]]
-            
-            #    polygon_points.InsertNextPoint(point)
-            
-            #
-            
-            ## Properly set up the polygon with points and point IDs
-            
-            #slice_polygon.GetPointIds().SetNumberOfIds(n_points)
-            
-            #for i in range(n_points):
-            
-            #    slice_polygon.GetPointIds().SetId(i, i)
-            
-            #slice_polygon.GetPoints().DeepCopy(polygon_points)
-            
-            #
-            
-            ##generate 100 random points between the min and max coordinates in the slice
-            
-            #random_slice_points = np.random.uniform(low=[min(slice_points[::3]), min(slice_points[1::3]), min(slice_points[2::3])],
-            
-            #                                        high=[max(slice_points[::3]), max(slice_points[1::3]), max(slice_points[2::3])],
-            
-            #                                        size=(1000, 3)) 
-            
-            #
-            
-            ## Compute normal - it's a static method that takes points array
-            
-            #polygon_normal = [0.0, 0.0, 0.0]
-            
-            #vtk.vtkPolygon.ComputeNormal(polygon_points, polygon_normal)
-            
-            #
-            
-            ## Get bounds
-            
-            #bounds = polygon_points.GetBounds()
-            
-            #
-            
-            #for point in random_slice_points:
-            
-            #    # PointInPolygon expects: point, numPoints, points (as double array), bounds, normal
-            
-            #    if slice_polygon.PointInPolygon(point, n_points, polygon_points.GetData(), bounds, polygon_normal) >= 0:
-            
-            #        points_list.append(list(point))
-        for i in range(0, len(slice_points), 3):
-            point = [slice_points[i], slice_points[i+1], slice_points[i+2]]
-            points_list.append(point)
+    raise NotImplementedError("The implementation of this conversion from " \
+        "slicewise polygons of the contours to a 3D structured mesh is highly non-trivial." \
+        "Please use mask_to_stl instead.")
 
-    print(f"Total number of raw points: {len(points_list)}")
-    #randomly sample 1000 points from the list
-    import random
-    points_list = random.sample(points_list, min(1000, len(points_list)))
-    structure_points = vtk.vtkPoints()
-    for point in points_list:
-        structure_points.InsertNextPoint(point)
-
-    print(f"Total number of points before cleaning: {structure_points.GetNumberOfPoints()}")
-
-    structure_polydata = vtk.vtkPolyData()
-    structure_polydata.SetPoints(structure_points)
-
-    # Adapted from VTK ExtractSurface example
-    # Get bounds of the points
-    bounds = structure_polydata.GetBounds()
-    range_vals = [
-        bounds[1] - bounds[0],
-        bounds[3] - bounds[2],
-        bounds[5] - bounds[4]
-    ]
+def mask_to_stl(roi_mask: ROIMask, pth_output: Path) -> None:
+    r"""
+    Purpose:
+        - Convert an ROI mask to an STL file.
     
-    # Estimate normals using PCANormalEstimation
-    sample_size = max(10, int(structure_polydata.GetNumberOfPoints() * 0.00005))
-    normals = vtk.vtkPCANormalEstimation()
-    normals.SetInputData(structure_polydata)
-    normals.SetSampleSize(sample_size)
-    normals.SetNormalOrientationToGraphTraversal()
-    normals.FlipNormalsOn()
+    Inputs:
+        - roi_mask: ROIMask := The ROI mask object containing the 3D binary mask data to be converted.
+        - pth_output: Path := The output file path where the STL file will be saved.
     
-    # Create signed distance field
-    dimension = 256
-    radius = max(range_vals) / dimension * 8 # ~8 voxels
+    Outputs:
+        - None
+    """
+
+    # Note: Implementation is cannablized from PolySeg (https://github.com/PerkLab/PolySeg/)
+    if not isinstance(roi_mask, ROIMask):
+        raise ValueError("The input roi_mask should be an instance of ROIMask.")
     
-    distance = vtk.vtkSignedDistance()
-    distance.SetInputConnection(normals.GetOutputPort())
-    distance.SetRadius(radius)
-    distance.SetDimensions(dimension, dimension, dimension)
-    distance.SetBounds(
-        bounds[0] - range_vals[0] * 0.1, bounds[1] + range_vals[0] * 0.1,
-        bounds[2] - range_vals[1] * 0.1, bounds[3] + range_vals[1] * 0.1,
-        bounds[4] - range_vals[2] * 0.1, bounds[5] + range_vals[2] * 0.1
+    # Get mask data in [z, y, x] format for VTK
+    mask_array = roi_mask.imageArray.astype(np.uint8)
+    
+    # Create VTK image data
+    vtk_image = vtk.vtkImageData()
+    vtk_image.SetDimensions(mask_array.shape)
+    vtk_image.SetSpacing(roi_mask.spacing)
+    vtk_image.SetOrigin(roi_mask.origin)
+    vtk_image.GetPointData().SetScalars(vtk.util.numpy_support.numpy_to_vtk(
+        num_array=mask_array.ravel(order='F'),
+        deep=True,
+        array_type=vtk.VTK_UNSIGNED_CHAR,
+    ))
+
+    
+    # Pad the image if border voxels are non-zero to ensure closed surface
+    extent = vtk_image.GetExtent()
+    padder = vtk.vtkImageConstantPad()
+    padder.SetInputData(vtk_image)
+    padder.SetOutputWholeExtent(
+        extent[0] - 1, extent[1] + 1,
+        extent[2] - 1, extent[3] + 1,
+        extent[4] - 1, extent[5] + 1
     )
+    padder.SetConstant(0)
+    padder.Update()
+    vtk_image = padder.GetOutput()
     
-    # Extract surface
-    surface = vtk.vtkExtractSurface()
-    surface.SetInputConnection(distance.GetOutputPort())
-    surface.SetRadius(radius * 0.99)
-    surface.Update()
+    # Use Flying Edges (faster than marching cubes) or Marching Cubes for surface extraction
+    marching_cubes = vtk.vtkDiscreteFlyingEdges3D()
 
-    #clean_points = vtk.vtkCleanPolyData()
-    #clean_points.SetInputConnection(surface.GetOutputPort())
-    #clean_points.SetTolerance(0)
-    #clean_points.Update()
-    #structure_polydata = clean_points.GetOutput()
+    marching_cubes.SetInputData(vtk_image)
+    marching_cubes.SetValue(0, 1)  # Extract surface at label value 1
+    marching_cubes.ComputeGradientsOff()
+    marching_cubes.ComputeNormalsOff()
+    marching_cubes.Update()
+    
+    poly_data = marching_cubes.GetOutput()
+    
+    if poly_data.GetNumberOfPolys() == 0:
+        raise ValueError("No surface could be generated from the mask. The mask may be empty.")
+    
 
-    fill_holes = vtk.vtkFillHolesFilter()
-    fill_holes.SetInputConnection(surface.GetOutputPort())
-    fill_holes.SetHoleSize(1000.0)  # Adjust hole size as needed
-    fill_holes.Update()
+    print(f"Pre-filtration mesh quality: {poly_data.GetNumberOfPolys()} polygons")
+    i = 0
+    while poly_data.GetNumberOfPolys() > 10000 and i < 10:
+        print(f"Current mesh quality: {poly_data.GetNumberOfPolys()} polygons")
+        # Apply decimation (0.0 = no decimation, using minimal decimation)
+        decimation_factor = 0.5
+        if decimation_factor > 0.0:
+            decimator = vtk.vtkDecimatePro()
+            decimator.SetInputData(poly_data)
+            decimator.SetTargetReduction(decimation_factor)
+            decimator.SetFeatureAngle(60)
+            decimator.SplittingOff()
+            decimator.PreserveTopologyOn()
+            decimator.SetMaximumError(1.0)
+            decimator.Update()
+            poly_data = decimator.GetOutput()
+                
+        # Apply smoothing (0.5 = moderate smoothing)
+        smoothing_factor = 1.0
+        if smoothing_factor > 0:
+            smoother = vtk.vtkWindowedSincPolyDataFilter()
+            smoother.SetInputData(poly_data)
+            smoother.SetNumberOfIterations(50)
+            # Map smoothing factor to pass band: 0.0->1.0, 0.5->0.01, 1.0->0.001
+            pass_band = pow(10.0, -4.0 * smoothing_factor)
+            smoother.SetPassBand(pass_band)
+            smoother.BoundarySmoothingOn()
+            smoother.FeatureEdgeSmoothingOn()
+            smoother.NonManifoldSmoothingOn()
+            smoother.NormalizeCoordinatesOn()
+            smoother.Update()
+            poly_data = smoother.GetOutput()
+        print(f"Iter {i+1} post-smoothing mesh quality: {poly_data.GetNumberOfPolys()} polygons")
+        i += 1
+        
+    print(f"Final mesh quality: {poly_data.GetNumberOfPolys()} polygons")
+        
+    # Write to STL file
+    writer = vtk.vtkSTLWriter()
+    writer.SetFileName(str(pth_output))
+    writer.SetInputData(poly_data)
+    writer.Write()
 
 
-    print(f"Number of points after cleaning: {surface.GetOutput().GetNumberOfPoints()}")
-
-    stl_writer = vtk.vtkSTLWriter()
-    stl_writer.SetFileName(str(pth_output))
-    stl_writer.SetInputConnection(fill_holes.GetOutputPort())
-    stl_writer.Write()
 
 def get_slicer_color_by_name(name: str) -> List[int]:
     r"""

--- a/brachyutils/geometry/phantom_utils.py
+++ b/brachyutils/geometry/phantom_utils.py
@@ -1954,6 +1954,17 @@ def mask_to_stl(roi_mask: ROIMask, pth_output: Path) -> None:
             poly_data = smoother.GetOutput()
         print(f"Iter {i+1} post-smoothing mesh quality: {poly_data.GetNumberOfPolys()} polygons")
         i += 1
+
+    #clean the mesh
+    cleaner = vtk.vtkCleanPolyData()
+    cleaner.SetInputData(poly_data)
+    cleaner.SetTolerance(1e-3)
+    cleaner.SetPointMerging(True)
+    cleaner.SetConvertLinesToPoints(True)
+    cleaner.SetConvertPolysToLines(True)
+    cleaner.SetConvertStripsToPolys(True)
+    cleaner.Update()
+    poly_data = cleaner.GetOutput()
         
     print(f"Final mesh quality: {poly_data.GetNumberOfPolys()} polygons")
         
@@ -1962,6 +1973,8 @@ def mask_to_stl(roi_mask: ROIMask, pth_output: Path) -> None:
     writer.SetFileName(str(pth_output))
     writer.SetInputData(poly_data)
     writer.Write()
+
+    print(f"STL file saved to {pth_output}")
 
 
 

--- a/brachyutils/geometry/phantom_utils.py
+++ b/brachyutils/geometry/phantom_utils.py
@@ -11,6 +11,9 @@ from pathlib import Path
 from copy import deepcopy
 from collections import defaultdict
 
+from vtk import vtkPolyData, vtkDelaunay2D, vtkPoints, vtkDecimatePro
+from vtkmodules.vtkIOGeometry import vtkSTLWriter
+
 import nrrd
 import pydicom
 
@@ -347,7 +350,7 @@ class BrachyPhantom:
     def get_structure_mask(
         self,
         query_structure_list: List[str],
-        mask_type: Union[np.ndarray, ROIContour, ROIMask] = ROIMask,
+        mask_type: Union[np.ndarray, ROIContour, ROIMask, str] = ROIMask,
         strict_name_match: bool = True,
     ) -> Dict[str, Union[np.ndarray, ROIContour, ROIMask]]:
         r"""
@@ -359,9 +362,9 @@ class BrachyPhantom:
         ### Inputs:
         - query_structure_list := list of structure names to find the mask of.
         - mask_type: Union[np.ndarray, ROIContour, ROIMask] := the type of the mask to return.
-            if np.ndarray, the mask will be returned as a numpy array in [z, y, x] format.
-            if ROIContour, the mask will be returned as a ROIContour object in [x, y, z] format.
-            if ROIMask, the mask will be returned as a ROIMask object in [x, y, z] format.
+            if np.ndarray (or str "array"), the mask will be returned as a numpy array in [z, y, x] format.
+            if ROIContour (or str "contour"), the mask will be returned as a ROIContour object in [x, y, z] format.
+            if ROIMask (or str "mask"), the mask will be returned as a ROIMask object in [x, y, z] format.
         ### Outputs:
         - mask_dict:dict :=  a dictionary with the queried structure name as key and the mask as value.
         """
@@ -398,15 +401,15 @@ class BrachyPhantom:
                         mask.origin = self.image_obj.origin
                         mask.spacing = self.image_obj.spacing
                         mask.gridSize = self.image_obj.gridSize
-                    if mask_type == np.ndarray:
+                    if mask_type == np.ndarray or mask_type == "array":
                         mask_dict[query_structure] = np.swapaxes(
                             mask.imageArray, 0, 2
                         )
-                    elif mask_type == ROIContour:
+                    elif mask_type == ROIContour or mask_type == "contour":
                         mask_dict[query_structure] = (
                             self.structure_set.getContourByName(mask_name)
                         )
-                    elif mask_type == ROIMask:
+                    elif mask_type == ROIMask or mask_type == "mask":
                         mask_dict[query_structure] = mask
                     else:
                         raise ValueError(f"mask_type {mask_type} not recognized")
@@ -1841,6 +1844,60 @@ def masksToNrrd(
 
         # # Write the image
         nrrd.write(str(pth_output), all_masks, header, index_order="C", compression_level=1)
+
+def contour_to_stl(roi_contour: ROIContour, pth_output: Path) -> None:
+    r"""
+    Purpose:
+        - Export the contour to an STL file via vtkPolyData
+    Inputs:
+        - roi_contour: ROIContour := the contour to export.
+        - pth_output: Path := the path to save the STL file.
+    Outputs:
+        - None
+    Dependencies:
+    """
+    #raise NotImplementedError("STL export of contours from ROIContour is not implement yet.")
+    #vertices, faces
+    if not isinstance(roi_contour, ROIContour):
+        raise ValueError("The input roi_contour should be an instance of ROIContour.")
+    structure_polygon_mesh = roi_contour.polygonMesh #each slice has a (1D) list of coordinates [x1, y1, z1, x2, y2, z2]
+    #structure coordinates into a single list of points (tuples)
+    points_list : List[Tuple[float, float, float]] = []
+    for i_slice, slice_points in enumerate(structure_polygon_mesh):
+        #if it's the first or last slice, we need to add in points manually inside to complete the top and bottom of the mesh
+        #if i_slice == 0 or i_slice == len(structure_polygon_mesh) - 1:
+        #    #get the centroid of the slice
+        #    xs = slice_points[0::3]
+        #    ys = slice_points[1::3]
+        #    zs = slice_points[2::3]
+        #    centroid = (sum(xs) / len(xs), sum(ys) / len(ys), sum(zs) / len(zs))
+        #    points_list.append(centroid)
+        for i in range(0, len(slice_points), 3):
+            point = [slice_points[i], slice_points[i+1], slice_points[i+2]]
+            points_list.append(point)
+    structure_points = vtk.vtkPoints()
+    for point in points_list:
+        structure_points.InsertNextPoint(point)
+
+    structure_polydata = vtk.vtkPolyData()
+    structure_polydata.SetPoints(structure_points)
+
+    
+    delaunay = vtk.vtkDelaunay2D()
+    delaunay.SetInputData(structure_polydata)
+    delaunay.Update()
+    structure_polydata = delaunay.GetOutput()
+
+    decimate = vtk.vtkDecimatePro()
+    decimate.SetInputData(structure_polydata)
+    #decimate.PreserveTopologyOn()
+    decimate.SetTargetReduction(0.01)
+    decimate.Update()
+
+    stl_writer = vtk.vtkSTLWriter()
+    stl_writer.SetFileName(str(pth_output))
+    stl_writer.SetInputData(structure_polydata)
+    stl_writer.Write()
 
 def get_slicer_color_by_name(name: str) -> List[int]:
     r"""

--- a/brachyutils/geometry/phantom_utils.py
+++ b/brachyutils/geometry/phantom_utils.py
@@ -1872,6 +1872,9 @@ def mask_to_stl(roi_mask: ROIMask, pth_output: Path) -> None:
     # Note: Implementation is cannablized from PolySeg (https://github.com/PerkLab/PolySeg/)
     if not isinstance(roi_mask, ROIMask):
         raise ValueError("The input roi_mask should be an instance of ROIMask.")
+
+    elif not pth_output.suffix.lower() == ".stl":
+        raise ValueError("The output file must have a .stl extension.")
     
     # Get mask data in [z, y, x] format for VTK
     mask_array = roi_mask.imageArray.astype(np.uint8)

--- a/brachyutils/geometry/phantom_utils.py
+++ b/brachyutils/geometry/phantom_utils.py
@@ -11,7 +11,7 @@ from pathlib import Path
 from copy import deepcopy
 from collections import defaultdict
 
-from vtk import vtkPolyData, vtkDelaunay2D, vtkPoints, vtkDecimatePro
+from vtk import vtkPolyData, vtkDelaunay2D, vtkPoints, vtkDecimatePro, vtkPolygon
 from vtkmodules.vtkIOGeometry import vtkSTLWriter
 
 import nrrd
@@ -1862,16 +1862,42 @@ def contour_to_stl(roi_contour: ROIContour, pth_output: Path) -> None:
         raise ValueError("The input roi_contour should be an instance of ROIContour.")
     structure_polygon_mesh = roi_contour.polygonMesh #each slice has a (1D) list of coordinates [x1, y1, z1, x2, y2, z2]
     #structure coordinates into a single list of points (tuples)
-    points_list : List[Tuple[float, float, float]] = []
+    points_list : List[List[float, float, float]] = []
     for i_slice, slice_points in enumerate(structure_polygon_mesh):
-        #if it's the first or last slice, we need to add in points manually inside to complete the top and bottom of the mesh
-        #if i_slice == 0 or i_slice == len(structure_polygon_mesh) - 1:
-        #    #get the centroid of the slice
-        #    xs = slice_points[0::3]
-        #    ys = slice_points[1::3]
-        #    zs = slice_points[2::3]
-        #    centroid = (sum(xs) / len(xs), sum(ys) / len(ys), sum(zs) / len(zs))
-        #    points_list.append(centroid)
+        if i_slice == 0 or i_slice == len(structure_polygon_mesh) - 1:
+            # Create vtkPoints object properly
+            polygon_points = vtk.vtkPoints()
+            slice_polygon = vtk.vtkPolygon()
+            
+            n_points = len(slice_points) // 3
+            for i in range(0, len(slice_points), 3):
+                point = [slice_points[i], slice_points[i+1], slice_points[i+2]]
+                polygon_points.InsertNextPoint(point)
+            
+            # Properly set up the polygon with points and point IDs
+            slice_polygon.GetPointIds().SetNumberOfIds(n_points)
+            for i in range(n_points):
+                slice_polygon.GetPointIds().SetId(i, i)
+            slice_polygon.GetPoints().DeepCopy(polygon_points)
+            
+            #generate 100 random points between the min and max coordinates in the slice
+            random_slice_points = np.random.uniform(low=[min(slice_points[::3]), min(slice_points[1::3]), min(slice_points[2::3])],
+                                                    high=[max(slice_points[::3]), max(slice_points[1::3]), max(slice_points[2::3])],
+                                                    size=(1000, 3)) 
+            
+            # Compute normal - it's a static method that takes points array
+            polygon_normal = [0.0, 0.0, 0.0]
+            vtk.vtkPolygon.ComputeNormal(polygon_points, polygon_normal)
+            print(f"Polygon normal for slice {i_slice}: {polygon_normal}")
+            exit(2)
+            
+            # Get bounds
+            bounds = polygon_points.GetBounds()
+            
+            for point in random_slice_points:
+                # PointInPolygon expects: point, numPoints, points (as double array), bounds, normal
+                if slice_polygon.PointInPolygon(point, n_points, polygon_points.GetData(), bounds, polygon_normal) >= 0:
+                    points_list.append(list(point))
         for i in range(0, len(slice_points), 3):
             point = [slice_points[i], slice_points[i+1], slice_points[i+2]]
             points_list.append(point)

--- a/brachyutils/geometry/phantom_utils.py
+++ b/brachyutils/geometry/phantom_utils.py
@@ -672,11 +672,7 @@ class BrachyPhantom:
             - background_material: Optional[str] := the name of the background material. default is "Air".
         """
         pth_output = Path(pth_output)
-        if str(pth_output).endswith(".egsphant"):
-            pass
-        elif str(pth_output).endswith(".seq.nrrd"):
-            pass
-        else:
+        if not str(pth_output).endswith(".egsphant") and not str(pth_output).endswith(".seq.nrrd"):
             raise ValueError("The output file should have '.egsphant' or '.seq.nrrd' extension.")
         #if the egsphant is already made, write it
         os.makedirs(os.path.dirname(pth_output), exist_ok=True)

--- a/brachyutils/geometry/phantom_utils.py
+++ b/brachyutils/geometry/phantom_utils.py
@@ -1865,64 +1865,139 @@ def contour_to_stl(roi_contour: ROIContour, pth_output: Path) -> None:
     points_list : List[List[float, float, float]] = []
     for i_slice, slice_points in enumerate(structure_polygon_mesh):
         if i_slice == 0 or i_slice == len(structure_polygon_mesh) - 1:
-            # Create vtkPoints object properly
-            polygon_points = vtk.vtkPoints()
-            slice_polygon = vtk.vtkPolygon()
+            pass
+            ## Create vtkPoints object properly
             
-            n_points = len(slice_points) // 3
-            for i in range(0, len(slice_points), 3):
-                point = [slice_points[i], slice_points[i+1], slice_points[i+2]]
-                polygon_points.InsertNextPoint(point)
+            #polygon_points = vtk.vtkPoints()
             
-            # Properly set up the polygon with points and point IDs
-            slice_polygon.GetPointIds().SetNumberOfIds(n_points)
-            for i in range(n_points):
-                slice_polygon.GetPointIds().SetId(i, i)
-            slice_polygon.GetPoints().DeepCopy(polygon_points)
+            #slice_polygon = vtk.vtkPolygon()
             
-            #generate 100 random points between the min and max coordinates in the slice
-            random_slice_points = np.random.uniform(low=[min(slice_points[::3]), min(slice_points[1::3]), min(slice_points[2::3])],
-                                                    high=[max(slice_points[::3]), max(slice_points[1::3]), max(slice_points[2::3])],
-                                                    size=(1000, 3)) 
+            #
             
-            # Compute normal - it's a static method that takes points array
-            polygon_normal = [0.0, 0.0, 0.0]
-            vtk.vtkPolygon.ComputeNormal(polygon_points, polygon_normal)
-            print(f"Polygon normal for slice {i_slice}: {polygon_normal}")
-            exit(2)
+            #n_points = len(slice_points) // 3
             
-            # Get bounds
-            bounds = polygon_points.GetBounds()
+            #for i in range(0, len(slice_points), 3):
             
-            for point in random_slice_points:
-                # PointInPolygon expects: point, numPoints, points (as double array), bounds, normal
-                if slice_polygon.PointInPolygon(point, n_points, polygon_points.GetData(), bounds, polygon_normal) >= 0:
-                    points_list.append(list(point))
+            #    point = [slice_points[i], slice_points[i+1], slice_points[i+2]]
+            
+            #    polygon_points.InsertNextPoint(point)
+            
+            #
+            
+            ## Properly set up the polygon with points and point IDs
+            
+            #slice_polygon.GetPointIds().SetNumberOfIds(n_points)
+            
+            #for i in range(n_points):
+            
+            #    slice_polygon.GetPointIds().SetId(i, i)
+            
+            #slice_polygon.GetPoints().DeepCopy(polygon_points)
+            
+            #
+            
+            ##generate 100 random points between the min and max coordinates in the slice
+            
+            #random_slice_points = np.random.uniform(low=[min(slice_points[::3]), min(slice_points[1::3]), min(slice_points[2::3])],
+            
+            #                                        high=[max(slice_points[::3]), max(slice_points[1::3]), max(slice_points[2::3])],
+            
+            #                                        size=(1000, 3)) 
+            
+            #
+            
+            ## Compute normal - it's a static method that takes points array
+            
+            #polygon_normal = [0.0, 0.0, 0.0]
+            
+            #vtk.vtkPolygon.ComputeNormal(polygon_points, polygon_normal)
+            
+            #
+            
+            ## Get bounds
+            
+            #bounds = polygon_points.GetBounds()
+            
+            #
+            
+            #for point in random_slice_points:
+            
+            #    # PointInPolygon expects: point, numPoints, points (as double array), bounds, normal
+            
+            #    if slice_polygon.PointInPolygon(point, n_points, polygon_points.GetData(), bounds, polygon_normal) >= 0:
+            
+            #        points_list.append(list(point))
         for i in range(0, len(slice_points), 3):
             point = [slice_points[i], slice_points[i+1], slice_points[i+2]]
             points_list.append(point)
+
+    print(f"Total number of raw points: {len(points_list)}")
+    #randomly sample 1000 points from the list
+    import random
+    points_list = random.sample(points_list, min(1000, len(points_list)))
     structure_points = vtk.vtkPoints()
     for point in points_list:
         structure_points.InsertNextPoint(point)
 
+    print(f"Total number of points before cleaning: {structure_points.GetNumberOfPoints()}")
+
     structure_polydata = vtk.vtkPolyData()
     structure_polydata.SetPoints(structure_points)
 
+    # Adapted from VTK ExtractSurface example
+    # Get bounds of the points
+    bounds = structure_polydata.GetBounds()
+    range_vals = [
+        bounds[1] - bounds[0],
+        bounds[3] - bounds[2],
+        bounds[5] - bounds[4]
+    ]
     
-    delaunay = vtk.vtkDelaunay2D()
-    delaunay.SetInputData(structure_polydata)
-    delaunay.Update()
-    structure_polydata = delaunay.GetOutput()
+    # Estimate normals using PCANormalEstimation
+    sample_size = max(10, int(structure_polydata.GetNumberOfPoints() * 0.00005))
+    normals = vtk.vtkPCANormalEstimation()
+    normals.SetInputData(structure_polydata)
+    normals.SetSampleSize(sample_size)
+    normals.SetNormalOrientationToGraphTraversal()
+    normals.FlipNormalsOn()
+    
+    # Create signed distance field
+    dimension = 256
+    radius = max(range_vals) / dimension * 8 # ~8 voxels
+    
+    distance = vtk.vtkSignedDistance()
+    distance.SetInputConnection(normals.GetOutputPort())
+    distance.SetRadius(radius)
+    distance.SetDimensions(dimension, dimension, dimension)
+    distance.SetBounds(
+        bounds[0] - range_vals[0] * 0.1, bounds[1] + range_vals[0] * 0.1,
+        bounds[2] - range_vals[1] * 0.1, bounds[3] + range_vals[1] * 0.1,
+        bounds[4] - range_vals[2] * 0.1, bounds[5] + range_vals[2] * 0.1
+    )
+    
+    # Extract surface
+    surface = vtk.vtkExtractSurface()
+    surface.SetInputConnection(distance.GetOutputPort())
+    surface.SetRadius(radius * 0.99)
+    surface.Update()
 
-    decimate = vtk.vtkDecimatePro()
-    decimate.SetInputData(structure_polydata)
-    #decimate.PreserveTopologyOn()
-    decimate.SetTargetReduction(0.01)
-    decimate.Update()
+    #clean_points = vtk.vtkCleanPolyData()
+    #clean_points.SetInputConnection(surface.GetOutputPort())
+    #clean_points.SetTolerance(0)
+    #clean_points.Update()
+    #structure_polydata = clean_points.GetOutput()
+
+    fill_holes = vtk.vtkFillHolesFilter()
+    fill_holes.SetInputConnection(surface.GetOutputPort())
+    fill_holes.SetHoleSize(1000.0)  # Adjust hole size as needed
+    fill_holes.Update()
+
+
+    print(f"Number of points after cleaning: {surface.GetOutput().GetNumberOfPoints()}")
 
     stl_writer = vtk.vtkSTLWriter()
     stl_writer.SetFileName(str(pth_output))
-    stl_writer.SetInputData(structure_polydata)
+    stl_writer.SetInputConnection(fill_holes.GetOutputPort())
     stl_writer.Write()
 
 def get_slicer_color_by_name(name: str) -> List[int]:

--- a/brachyutils/planning/plan_utils.py
+++ b/brachyutils/planning/plan_utils.py
@@ -1132,6 +1132,7 @@ class BrachyPlan:
                     assign_material_from_ct=content_to_export.get("assign_material_from_ct", True),
                     crop_by_contour=content_to_export.get("crop_by_contour", None),
                     strict_name_match=content_to_export.get("strict_name_match", True),
+                    phantom_filename=content_to_export.get("phantom_filename", "ct.egsphant"),
                     resampled_spacing=content_to_export.get("resampled_spacing", None),
                     resampled_origin=content_to_export.get("resampled_origin", None),
                     background_material=content_to_export.get("background_material", "Air"),
@@ -1380,7 +1381,9 @@ class BrachyPlan:
         resampled_spacing: List[float] = None,
         resampled_origin: List[float] = None,
         background_material: str = None,
-        strict_name_match: bool = True
+        strict_name_match: bool = True,
+        phantom_filename: str = "ct.egsphant",
+
     ):
         r"""
         ### Purpose:
@@ -1395,18 +1398,22 @@ class BrachyPlan:
             "structure_name := {optional} the name of the structure in the dicom file that represents the material,"
         ]
         - assign_material_from_ct := if True, the material names will be assigned from the ct.egsphant file.
+        - output_filename: str := the name of the output egsphant file
+
         ### Outputs:
         - void := egsphant file is generated from phantom and is written to ct.egsphant
         ### Dependencies:
         - BrachyEgsphant
         """
-        file_path = dir_export + "/ct.egsphant"
+        if isinstance(dir_export, str):
+            dir_export = Path(dir_export)
+        file_path = dir_export / phantom_filename
         # if isinstance(material_dict, Path):
         #     with open(material_dict, "r") as json_file:
         #         material_dict = json.load(json_file)
 
         self.phantom.write_to_egsphant(
-            pth_output=Path(file_path),
+            pth_output=file_path,
             material_dict=material_dict,
             assign_material_from_ct=assign_material_from_ct,
             crop_by_contour=crop_by_contour,


### PR DESCRIPTION
Adds the following functionality: 

- Exporting of `ROIMask` to STL files enabled via the `mask_to_stl` utility function implemented in `BrachyPhantom`. This functionality was dosimetrically validated on 10 HDR prostate patients, written up into an abstract submitted to COMP/AAPM.
- Some minor fixes to `BrachyEgsphant` including proper encoding for exporting to .nrrd from an imported .nrrd phantom, changing the nrrd data type to 'list' for 3D Slicer compatability, and better managing the precision of voxel edge coordinates (not rounding them until the output).