### PR TITLE
Cleaner Dynamic Catheter table

### DIFF
--- a/brachyutils/dose/dose_generation_utils.py
+++ b/brachyutils/dose/dose_generation_utils.py
@@ -229,7 +229,7 @@ class DoseTG43(BrachyDoseGenerator):
         )
         # load the generated dose maps and update the plan
         if generate_dose_rate_maps:
-            plan.load_dose_rate_dict(
+            plan.load_dose_rates(
                 dir_dose_rate=self.dir_plan_export,
             )
         else:

--- a/brachyutils/dose/dose_generation_utils.py
+++ b/brachyutils/dose/dose_generation_utils.py
@@ -199,7 +199,6 @@ class DoseTG43(BrachyDoseGenerator):
 
     def run_dose_generation(
         self,
-        dir_export: str | Path = None,
         plan: BrachyPlan = None,
         generate_dose_rate_maps: bool = False,
         export_config_brachyplan: ExportConfig_BrachyPlan = None,
@@ -209,7 +208,6 @@ class DoseTG43(BrachyDoseGenerator):
         - to run the dose generation for the plan and return a plan with combined dose filled as well
         as the dose rate dictionary if desired.
         ### Inputs:
-        - dir_export := The directory used for exporting the dosimetry setup and the generated dose maps.
         - plan:= The treatment plan for which we want to generate the dose. 
         - generate_dose_rate_maps := whether to generate dose rate maps for each dwell position.
         If True, the dose_rate_dict will be populated with the dose rate maps for each dwell position.
@@ -217,18 +215,9 @@ class DoseTG43(BrachyDoseGenerator):
         ### Output:
         - plan: BrachyPlan := The brachy plan with the combined dose and optionally the dose rate dict filled.
         """
-        plan_name = plan.phantom.pth_image.stem
-        if "." in plan_name:
-            plan_name = plan_name.split(".")[0]
-
-        if dir_export is None:
-            dir_export = Path("temp_data/tg43/")/plan_name
-
-        dir_export = Path(dir_export)
-        # export the plan for dosimetry
         if export_config_brachyplan is None:
             export_config_brachyplan = ExportConfig_BrachyPlan(
-                dir_export=dir_export,
+                dir_export=self.dir_plan_export,
                 export_config_egsphant=True,
                 export_config_planfile=True,
                 export_config_macfile=True,
@@ -241,7 +230,7 @@ class DoseTG43(BrachyDoseGenerator):
         # load the generated dose maps and update the plan
         if generate_dose_rate_maps:
             plan.load_dose_rate_dict(
-                dir_dose_rate=dir_export,
+                dir_dose_rate=self.dir_plan_export,
             )
         else:
             plan.combined_dose = BrachyDose(

--- a/brachyutils/dose/dose_generation_utils.py
+++ b/brachyutils/dose/dose_generation_utils.py
@@ -2,6 +2,8 @@ from abc import ABC, abstractmethod
 from glob import glob
 from pathlib import Path
 from typing import Literal, Optional, Union
+from brachyutils.planning.plan_utils import BrachyPlan, ExportConfig_BrachyPlan
+from brachyutils.dose.dose_utils import BrachyDose
 
 class BrachyDoseGenerator(ABC):
     def __init__(
@@ -45,7 +47,27 @@ class BrachyDoseGenerator(ABC):
             - pth_output: Optional[Path]: If provided, the dose distribution will be saved to this path.
         """
         pass
-
+    
+    @abstractmethod
+    def run_dose_generation(
+        self,
+        dir_export: str | Path = None,
+        plan: BrachyPlan = None,
+        generate_dose_rate_maps: bool = False,
+        ) -> BrachyPlan:
+        r"""
+        ### Purpose:
+        - to run the dose generation for the plan and return a plan with combined dose filled as well
+        as the dose rate dictionary if desired.
+        ### Inputs:
+        - dir_export := The directory used for exporting the dosimetry setup and the generated dose maps.
+        - plan:= The treatment plan for which we want to generate the dose. 
+        - generate_dose_rate_maps := whether to generate dose rate maps for each dwell position.
+        If True, the dose_rate_dict will be populated with the dose rate maps for each dwell position.
+        ### Output:
+        - plan: BrachyPlan := The brachy plan with the combined dose and optionally the dose rate dict filled.
+        """
+        pass
 
 class DoseTG43(BrachyDoseGenerator):
     def __init__(
@@ -175,6 +197,56 @@ class DoseTG43(BrachyDoseGenerator):
         ), "The egsphant file is missing."
         assert any(".mac" in file for file in all_files), "The mac file is missing."
 
+    def run_dose_generation(
+        self,
+        dir_export: str | Path = None,
+        plan: BrachyPlan = None,
+        generate_dose_rate_maps: bool = False,
+        export_config_brachyplan: ExportConfig_BrachyPlan = None,
+        ) -> BrachyPlan:
+        r"""
+        ### Purpose:
+        - to run the dose generation for the plan and return a plan with combined dose filled as well
+        as the dose rate dictionary if desired.
+        ### Inputs:
+        - dir_export := The directory used for exporting the dosimetry setup and the generated dose maps.
+        - plan:= The treatment plan for which we want to generate the dose. 
+        - generate_dose_rate_maps := whether to generate dose rate maps for each dwell position.
+        If True, the dose_rate_dict will be populated with the dose rate maps for each dwell position.
+        - export_config_brachyplan := The 
+        ### Output:
+        - plan: BrachyPlan := The brachy plan with the combined dose and optionally the dose rate dict filled.
+        """
+        plan_name = plan.phantom.pth_image.stem
+        if "." in plan_name:
+            plan_name = plan_name.split(".")[0]
+
+        if dir_export is None:
+            dir_export = Path("temp_data/tg43/")/plan_name
+
+        dir_export = Path(dir_export)
+        # export the plan for dosimetry
+        if export_config_brachyplan is None:
+            export_config_brachyplan = ExportConfig_BrachyPlan(
+                dir_export=dir_export,
+                export_config_egsphant=True,
+                export_config_planfile=True,
+                export_config_macfile=True,
+            )
+        plan.export_brachy_plan(export_config_brachyplan)
+        # call the dose generator to generate the dose maps
+        self.generate_dose(
+            output_dose_per_dwell= "dose_rate" if generate_dose_rate_maps else False,
+        )
+        # load the generated dose maps and update the plan
+        if generate_dose_rate_maps:
+            plan.load_dose_rate_dict(
+                dir_dose_rate=dir_export,
+            )
+        else:
+            plan.combined_dose = BrachyDose(
+                export_config_brachyplan.export_config_macfile.pth_combined.with_suffix(".seq.nrrd")
+                )
 
 class DoseMonteCarlo(BrachyDoseGenerator):
     def __init__(
@@ -246,3 +318,26 @@ class DoseMonteCarlo(BrachyDoseGenerator):
                     "The dose executable is not supported. It should be a URL or a python script."
                 )
             return response
+
+    def run_dose_generation(
+        self,
+        dir_export: str | Path = None,
+        plan: BrachyPlan = None,
+        generate_dose_rate_maps: bool = False,
+        export_config_brachyplan: ExportConfig_BrachyPlan = None,
+        ) -> BrachyPlan:
+        r"""
+        ### Purpose:
+        - to run the dose generation for the plan and return a plan with combined dose filled as well
+        as the dose rate dictionary if desired.
+        ### Inputs:
+        - dir_export := The directory used for exporting the dosimetry setup and the generated dose maps.
+        - plan:= The treatment plan for which we want to generate the dose. 
+        - generate_dose_rate_maps := whether to generate dose rate maps for each dwell position.
+        If True, the dose_rate_dict will be populated with the dose rate maps for each dwell position.
+        ### Output:
+        - plan: BrachyPlan := The brachy plan with the combined dose and optionally the dose rate dict filled.
+        TODO examples/benchmarks/eval_dose_generation.py has the code to fill this function. will do it when 
+        I need it again!
+        """
+        pass

--- a/brachyutils/dose/dose_generation_utils.py
+++ b/brachyutils/dose/dose_generation_utils.py
@@ -139,6 +139,11 @@ class DoseTG43(BrachyDoseGenerator):
         else:
             raise ValueError("Invalid value for output_dose_per_dwell.")
 
+        if pth_egsphant is None:
+            pth_egsphant = list(self.dir_plan_export.glob("*egsphant.seq.nrrd")).pop()
+        if pth_mac is None:
+            pth_mac = list(self.dir_plan_export.glob("combined.mac")).pop()
+
         if "http" in self.pth_dose_executable:
             # use fast api post to request the dose calculation
             import requests
@@ -201,7 +206,7 @@ class DoseTG43(BrachyDoseGenerator):
         self,
         plan: BrachyPlan = None,
         generate_dose_rate_maps: bool = False,
-        export_config_brachyplan: ExportConfig_BrachyPlan = None,
+        export_config_brachyplan: ExportConfig_BrachyPlan | bool | dict = None,
         ) -> BrachyPlan:
         r"""
         ### Purpose:
@@ -211,31 +216,41 @@ class DoseTG43(BrachyDoseGenerator):
         - plan:= The treatment plan for which we want to generate the dose. 
         - generate_dose_rate_maps := whether to generate dose rate maps for each dwell position.
         If True, the dose_rate_dict will be populated with the dose rate maps for each dwell position.
-        - export_config_brachyplan := The 
+        - export_config_brachyplan := If false, we assume the egsphant, mac files, and plan files have been
+        exported before. If True or None, we create a default ExportConfig_BrachyPlan to export the setup files
+        needed for DoseTG43. You can also provide your own custom export config.
         ### Output:
         - plan: BrachyPlan := The brachy plan with the combined dose and optionally the dose rate dict filled.
         """
-        if export_config_brachyplan is None:
+        if export_config_brachyplan is None or export_config_brachyplan == True:
             export_config_brachyplan = ExportConfig_BrachyPlan(
                 dir_export=self.dir_plan_export,
                 export_config_egsphant=True,
                 export_config_planfile=True,
                 export_config_macfile=True,
             )
-        plan.export_brachy_plan(export_config_brachyplan)
+        elif isinstance(export_config_brachyplan, dict):
+            export_config_brachyplan = ExportConfig_BrachyPlan(**export_config_brachyplan)
+
+        if export_config_brachyplan:
+            plan.export_brachy_plan(export_config_brachyplan)
+
         # call the dose generator to generate the dose maps
         self.generate_dose(
+            pth_mac=export_config_brachyplan.export_config_macfile.pth_combined,
+            pth_plan=export_config_brachyplan.export_config_planfile.pth_combined,
             output_dose_per_dwell= "dose_rate" if generate_dose_rate_maps else False,
         )
         # load the generated dose maps and update the plan
         if generate_dose_rate_maps:
-            plan.load_dose_rates(
+            plan.catheter_table.load_dose_rates(
                 dir_dose_rate=self.dir_plan_export,
             )
         else:
             plan.combined_dose = BrachyDose(
                 export_config_brachyplan.export_config_macfile.pth_combined.with_suffix(".seq.nrrd")
                 )
+        return plan
 
 class DoseMonteCarlo(BrachyDoseGenerator):
     def __init__(

--- a/brachyutils/dose/dose_utils.py
+++ b/brachyutils/dose/dose_utils.py
@@ -73,6 +73,7 @@ class BrachyDose:
         self,
         pth_dose_file: Optional[Path] | tuple[np.ndarray, defaultdict] = None,
         load_uncertainty: Optional[bool] = True,
+        dtype=np.float32
     ):
         self.path = Path(pth_dose_file) if pth_dose_file else None
         self.dose_image: DoseImage = None
@@ -87,9 +88,12 @@ class BrachyDose:
         self.unit_length: Literal["mm"] = "mm"
         self.xyz_format: bool = True
         self.modification_time:float = self.path.stat().st_mtime if self.path else None
+        self.dose_image.imageArray = self.dose_image.imageArray.astype(dtype)
+        if self.uncertainty_image is not None:
+            self.uncertainty_image.imageArray = self.uncertainty_image.imageArray.astype(dtype)
 
     def load_file_to_brachydose(
-        self, pth_dose_file: Path, load_uncertainty: Optional[bool] = True
+        self, pth_dose_file: Path, load_uncertainty: Optional[bool] = True,
     ) -> None:
         r"""
         Purpose:

--- a/brachyutils/dose/dose_utils.py
+++ b/brachyutils/dose/dose_utils.py
@@ -22,7 +22,7 @@ from numpy import ma, reshape
 from opentps.core.data.images import DoseImage
 from scipy.interpolate import RegularGridInterpolator
 
-from brachyutils.geometry import BrachyPhantom
+from brachyutils.geometry.phantom_utils import BrachyPhantom
 
 
 class BrachyDose:

--- a/brachyutils/dose/dose_utils.py
+++ b/brachyutils/dose/dose_utils.py
@@ -88,7 +88,8 @@ class BrachyDose:
         self.unit_length: Literal["mm"] = "mm"
         self.xyz_format: bool = True
         self.modification_time:float = self.path.stat().st_mtime if self.path else None
-        self.dose_image.imageArray = self.dose_image.imageArray.astype(dtype)
+        if self.dose_image is not None:
+            self.dose_image.imageArray = self.dose_image.imageArray.astype(dtype)
         if self.uncertainty_image is not None:
             self.uncertainty_image.imageArray = self.uncertainty_image.imageArray.astype(dtype)
 

--- a/brachyutils/geometry/__init__.py
+++ b/brachyutils/geometry/__init__.py
@@ -4,9 +4,9 @@ __all__ = [
     "BrachyPhantomRegistration",
     "BrachyEgsphant",
     "_load_json",
-    "DwellPosition",
-    "Catheter",
-    "CatheterTable",
+    # "DwellPosition",
+    # "Catheter",
+    # "CatheterTable",
     "get_uniform_phantom",
     "contour_to_stl",
     "mask_to_stl",
@@ -24,7 +24,7 @@ from .egsphant_utils import _load_json
 from .applicator_utils import BrachyApplicator
 
 # trunk-ignore(ruff/F401)
-from .catheter_utils import DwellPosition, Catheter, CatheterTable
+# from .catheter_utils import DwellPosition, Catheter, CatheterTable
 
 # trunk-ignore(ruff/F401)
 from .registration_utils import BrachyPhantomRegistration

--- a/brachyutils/geometry/__init__.py
+++ b/brachyutils/geometry/__init__.py
@@ -24,7 +24,7 @@ from .egsphant_utils import _load_json
 from .applicator_utils import BrachyApplicator
 
 # trunk-ignore(ruff/F401)
-from .catheter_utils import DwellPosition, Catheter, CatheterTable
+# from .catheter_utils import DwellPosition, Catheter, CatheterTable
 
 # trunk-ignore(ruff/F401)
 from .registration_utils import BrachyPhantomRegistration

--- a/brachyutils/geometry/__init__.py
+++ b/brachyutils/geometry/__init__.py
@@ -24,7 +24,7 @@ from .egsphant_utils import _load_json
 from .applicator_utils import BrachyApplicator
 
 # trunk-ignore(ruff/F401)
-# from .catheter_utils import DwellPosition, Catheter, CatheterTable
+from .catheter_utils import DwellPosition, Catheter, CatheterTable
 
 # trunk-ignore(ruff/F401)
 from .registration_utils import BrachyPhantomRegistration

--- a/brachyutils/geometry/catheter_utils/catheter_table.py
+++ b/brachyutils/geometry/catheter_utils/catheter_table.py
@@ -816,25 +816,36 @@ class CatheterTable(BaseModel):
         """
         if not isinstance(other, CatheterTable):
             raise ValueError("other should be a CatheterTable object.")
-        self.catheters_list += other.catheters_list
+        self.catheters_dict = self.catheters_dict | other.catheters_dict
         if self.step_size != other.step_size:
             raise ValueError("Cannot add two catheter tables with different stepsizes.")
         return self
 
-    def __delitem__(self, index: int | slice):
+    def __delitem__(self, indicies: int | slice | str):
         r"""
         ### Purpose:
-        - To delete a catheter from the catheter table.
+        - To delete a few catheters from the catheter table.
 
         ### Inputs:
         - self := the CatheterTable object.
-        - index: int | slice := the index or slice of the catheter to be deleted.
+        - indicies: int | slice | str:= the index, slice or the specific name id
+        of the catheter to be deleted.
 
         ### Outputs:
         - None
         """
-        del self.catheters_list[index]
-        self.reset_index()
+        if isinstance(indices, str):
+            del self.catheters_dict.get(indices)
+        if isinstance(indices, slice):
+            indices = list(range(*slice.indices(len(self.catheters_dict))))
+            name_ids = [str(index+1) for index in indices]
+            for name_id in name_ids:
+                del self.catheters_dict[name_id]
+
+        elif isinstance(indices, int):
+            if indices < 0 or indices >= len(self.catheters_dict):
+                return None
+            del self.catheters_dict[f"{indices+1}"]
 
     def __sub__(self, other: "CatheterTable") -> "CatheterTable":
         r"""

--- a/brachyutils/geometry/catheter_utils/catheter_table.py
+++ b/brachyutils/geometry/catheter_utils/catheter_table.py
@@ -205,7 +205,7 @@ class Catheter(BaseModel):
 
     @computed_field
     def name_id(self) -> str:
-        return f"{self.catheter_index+1}"
+        return f"{self.index+1}"
 
     @computed_field
     def channel_total_time(self) -> float:
@@ -913,7 +913,10 @@ class CatheterTable(BaseModel):
     def append(self, catheter: Catheter) -> None:
         r"""
         ### Purpose:
-        - To append a catheter to the catheter table.
+        - To append a catheter to the catheter table. Appending
+        will over-write the catheter.index based on the largest
+        index in self. If you would like to preserve the catheter.index
+        use __setitem__
 
         ### Inputs:
         - self := the CatheterTable object.
@@ -924,9 +927,12 @@ class CatheterTable(BaseModel):
         """
         if not isinstance(catheter, Catheter):
             raise ValueError("catheter should be a Catheter object.")
-        new_index = len(self.catheters_list)
+        new_index = len(self.catheters_dict)
         catheter.index = new_index
-        self.catheters_list.append(catheter)
+        self.catheters_list[catheter.name_id] = catheter
+
+    def __setitem__(self, name_id: str, new_catheter: dict | Catheter):
+        pass
 
     def get_dwells_by_name_ids(self, name_ids: List[str]) -> List[DwellPosition]:
         r"""

--- a/brachyutils/geometry/catheter_utils/catheter_table.py
+++ b/brachyutils/geometry/catheter_utils/catheter_table.py
@@ -1162,7 +1162,7 @@ agree with the sum of dwells times that have dose rates ({sanity_time})")
                     futures = {
                         executor.submit(
                             _write_single_dose_rate,
-                            self.dose_rate_dict.get(dose_rate_name),
+                            dose_rate_dict.get(dose_rate_name),
                             dir_export,
                             export_config_dose.file_extension,
                             f"run_{dose_rate_name}"):

--- a/brachyutils/geometry/catheter_utils/catheter_table.py
+++ b/brachyutils/geometry/catheter_utils/catheter_table.py
@@ -545,7 +545,7 @@ class CatheterTable(BaseModel):
 
     catheters_dict: Union[
         List[Catheter], List[dict], str, Path, CatheterSetUp, CreatedSetUp,
-        Dict[Catheter], Dict[dict]
+        Dict[str, Catheter], Dict[str, dict]
     ]
     step_size: float = 5.0
     from_delivered_dwellpositions: bool = False
@@ -854,7 +854,7 @@ in the catheters_dict. there is a big bug somewhere in catheter table creation")
         - None
         """
         if isinstance(indices, str):
-            del self.catheters_dict.get(indices)
+            del self.catheters_dict[indices]
         if isinstance(indices, slice):
             indices = list(range(*slice.indices(len(self.catheters_dict))))
             name_ids = [str(index+1) for index in indices]

--- a/brachyutils/geometry/catheter_utils/catheter_table.py
+++ b/brachyutils/geometry/catheter_utils/catheter_table.py
@@ -530,7 +530,7 @@ class CatheterTable(BaseModel):
     step_size: float = 5.0
     from_delivered_dwellpositions: bool = False
     _cached_combined_dose: 'BrachyDose' = None
-    _time_diffs:Dict[str, DwellPosition] = None
+    _time_diffs:Dict[str, float] = None
 
     @computed_field
     def all_dwells(self) -> List[DwellPosition]:
@@ -739,6 +739,7 @@ class CatheterTable(BaseModel):
             return CatheterTable(
                 catheter_list=self.catheter_list[indices],
                 step_size=self.step_size,
+                from_delivered_dwellpositions=self.from_delivered_dwellpositions,
             )
         elif isinstance(indices, int):
             if indices < 0 or indices >= len(self.catheter_list):

--- a/brachyutils/geometry/catheter_utils/catheter_table.py
+++ b/brachyutils/geometry/catheter_utils/catheter_table.py
@@ -763,9 +763,14 @@ class CatheterTable(BaseModel):
         ### Outputs:
         - List[Catheter] := the list of catheters in the catheter table.
         """
+        if isinstance(indices, str):
+            return self.catheters_dict.get(indices, None)
+
         if isinstance(indices, slice):
+            indices = list(range(*slice.indices(len(self.catheters_dict))))
+            caths_found = [cath for cath in self.catheters_list if cath.index in indices]
             return CatheterTable(
-                catheters_dict=self.catheters_dict[indices],
+                catheters_dict=caths_found,
                 step_size=self.step_size,
                 from_delivered_dwellpositions=self.from_delivered_dwellpositions,
             )

--- a/brachyutils/geometry/catheter_utils/catheter_table.py
+++ b/brachyutils/geometry/catheter_utils/catheter_table.py
@@ -24,7 +24,7 @@ from itertools import chain
 from brachyutils.dose.dose_utils import BrachyDose
 
 class ExportConfig_Dose(BaseModel):
-    """
+    """XXX : move this back to where it came from!
     Configuration for exporting dose data from the plan.
     """
     model_config = ConfigDict(

--- a/brachyutils/geometry/catheter_utils/catheter_table.py
+++ b/brachyutils/geometry/catheter_utils/catheter_table.py
@@ -415,6 +415,7 @@ class Catheter(BaseModel):
                         "position":point,
                         "relativePos":dwell_index * step_size,
                         "rotation":None,
+                        "catheter_index": self.index
                         # time:kwargs.get("time"),
                     }
                 )

--- a/brachyutils/geometry/catheter_utils/catheter_table.py
+++ b/brachyutils/geometry/catheter_utils/catheter_table.py
@@ -649,7 +649,8 @@ class CatheterTable(BaseModel):
             else dwell.time
             )
             if dwell_time != 0:
-                self._cached_combined_dose.dose_image.imageArray += dwell.dose_rate * dwell_time
+                self._cached_combined_dose.dose_image.imageArray += (
+                    dwell.dose_rate.dose_image.imageArray * dwell_time)
         # reset the time diffs for future
         self._time_diffs = None
         return self._cached_combined_dose

--- a/brachyutils/geometry/catheter_utils/catheter_table.py
+++ b/brachyutils/geometry/catheter_utils/catheter_table.py
@@ -830,7 +830,7 @@ in the catheters_dict. there is a big bug somewhere in catheter table creation")
             raise ValueError("Cannot add two catheter tables with different stepsizes.")
         return CatheterTable(
             catheters_dict=self.catheters_dict | other.catheters_dict,
-            stepsize=self.stepsize,
+            stepsize=self.step_size,
             from_delivered_dwellpositions=self.from_delivered_dwellpositions,
         )
 
@@ -944,7 +944,7 @@ in the catheters_dict. there is a big bug somewhere in catheter table creation")
                         index=other_catheter.index,
                         dwells=list_dwell_diffs)
         return CatheterTable(
-            catheters_list=dict_catheter_diffs,
+            catheters_dict=dict_catheter_diffs,
             from_delivered_dwellpositions=self.from_delivered_dwellpositions
         )
 

--- a/brachyutils/geometry/catheter_utils/catheter_table.py
+++ b/brachyutils/geometry/catheter_utils/catheter_table.py
@@ -976,9 +976,9 @@ match its index, be sure that the name_id == new_catheter.index +1")
         """
         out_catheters = []
         for name_id in name_ids:
-            for cath in self.catheters_list:
-                if cath.name_id == name_id:
-                    out_catheters.append(cath)
+            out_catheters.append(
+                self[name_id]
+            )
         return out_catheters
 
     def reset_index(self) -> None:

--- a/brachyutils/geometry/catheter_utils/catheter_table.py
+++ b/brachyutils/geometry/catheter_utils/catheter_table.py
@@ -20,6 +20,7 @@ from brachyutils.dose.dose_utils import BrachyDose
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from tqdm import tqdm
 from collections import defaultdict
+from itertools import chain
 
 class DwellPosition(BaseModel):
     r"""
@@ -280,6 +281,13 @@ class Catheter(BaseModel):
             if indices < 0 or indices >= len(self.dwells):
                 return None
             return self.dwells[indices]
+    
+    def __iter__(self):
+        for dwell in self.dwells:
+            yield dwell
+
+    def __len__(self):
+        return len(self.dwells)
 
     def to_dict(self, total_time=None) -> dict:
         r"""
@@ -1013,7 +1021,15 @@ class CatheterTable(BaseModel):
         pth_dose_rate = Path(dir_dose_rate).resolve()
         if not pth_dose_rate.exists():
             raise ValueError(f"directory of dose rates does not exist: {pth_dose_rate}")
+
+        # figure out which dwells we want to load dose rates for
+        all_dwells = self.
+        
         dose_rate_files = list(pth_dose_rate.glob("run_*.seq.nrrd"))
+
+        # if len(dose_rate_files) > self.num_dwell_positions:
+        #     raise ValueError("Cannot have more dose rates than dwells for a catheter table.")
+
         new_dose_rate_files = []
         # load file if they have not been loaded since modification
         for pth in dose_rate_files:
@@ -1021,7 +1037,7 @@ class CatheterTable(BaseModel):
             cat_index_from_pth, dwell_index_from_pth = pth.name.split("_")[1:3]
             cat_index_from_pth, dwell_index_from_pth = int(cat_index_from_pth)-1, int(dwell_index_from_pth)-1
             if 0 <= cat_index_from_pth < len(self):
-                dwells = catheter_table[cat_index_from_pth].dwells
+                dwells = self[cat_index_from_pth].dwells
                 if 0 <= dwell_index_from_pth < len(dwells):
                     pass
                 else:

--- a/brachyutils/geometry/catheter_utils/catheter_table.py
+++ b/brachyutils/geometry/catheter_utils/catheter_table.py
@@ -769,7 +769,7 @@ class CatheterTable(BaseModel):
         if isinstance(indices, slice):
             indices = list(range(*slice.indices(len(self.catheters_dict))))
             name_ids = [str(index+1) for index in indices]
-            caths_found = {name_id: self.catheters_dict[name_id] for name_id in name_ids}
+            caths_found = {name_id: self.catheters_dict.get(name_id, None) for name_id in name_ids}
             return CatheterTable(
                 catheters_dict=caths_found,
                 step_size=self.step_size,
@@ -778,7 +778,7 @@ class CatheterTable(BaseModel):
         elif isinstance(indices, int):
             if indices < 0 or indices >= len(self.catheters_dict):
                 return None
-            return self.catheters_dict[f"{indices+1}"]
+            return self.catheters_dict.get(f"{indices+1}", None)
 
     def __add__(self, other: "CatheterTable") -> "CatheterTable":
         r"""
@@ -850,8 +850,11 @@ class CatheterTable(BaseModel):
     def __sub__(self, other: "CatheterTable") -> "CatheterTable":
         r"""
         ### Purpose:
-        - To subtract the dwell times, position and rotation of one catheter table
-        from the current catheter table. This subtraction excludes the dose rates.
+        - To take the difference between self and other catheter table. If a catheter in the
+        other catheter table does not exist in self (name_id) not found, the entire catheter 
+        will be included in the difference. If the other catheter exists in self, the dwell times,
+        position and rotation of that catheter is subtracted from from the self catheter.
+        This subtraction excludes the dose rates.
         gen_dose_rate is set to true if the position, rotation or angle has changed.
 
         ### Inputs:
@@ -862,50 +865,48 @@ class CatheterTable(BaseModel):
         """
         if not isinstance(other, CatheterTable):
             raise ValueError("other should be a CatheterTable object.")
-        list_catheter_diffs = []
+        dict_catheter_diffs = defaultdict(Catheter)
         list_dwell_diffs = []
-        #if len(new_cat_table) != len(other):
-        #    raise ValueError("The two catheter tables should have the same number of catheters to be subtracted.")
-        for catheter in self.catheters_list:
-            for other_catheter in other.catheters_list:
-                if catheter.index == other_catheter.index:
-                    #if len(catheter.dwells) != len(other_catheter.dwells):
-                    #    raise ValueError("The two catheters should have the same number of dwell positions to be subtracted.")
-                    for dwell in catheter.dwells:
-                        for other_dwell in other_catheter.dwells:
-                            if dwell.index == other_dwell.index:
-                                diff_time = dwell.time - other_dwell.time
-                                diff_angle = dwell.angle - other_dwell.angle
-                                diff_relativePos = dwell.relativePos - dwell.relativePos
-                                diff_position = np.zeros(3)
-                                diff_rotation = np.zeros(3)
-                                for i in range(3):
-                                    diff_position[i] = dwell.position[i] - other_dwell.position[i]
-                                    diff_rotation[i] = dwell.rotation[i] - other_dwell.rotation[i]
-                                # gen dose rate if any attribute other than the dwell time has changed.
-                                diff_gen_doserate = False
-                                if (np.any(diff_position !=0) or np.any(diff_rotation !=0)
-                                    or diff_angle != 0):
-                                    diff_gen_doserate = True
-                                dwell_diff = DwellPosition(
-                                    index=dwell.index,
-                                    angle=diff_angle,
-                                    position=diff_position,
-                                    relativePos=diff_relativePos,
-                                    rotation=diff_rotation,
-                                    time=diff_time,
-                                    gen_dose_rate=diff_gen_doserate,
-                                    catheter_index=catheter.index
-                                )
-                                list_dwell_diffs.append(dwell_diff)
-                                
-                    list_catheter_diffs.append(
-                        Catheter(
-                            index=catheter.index,
-                            dwells=list_dwell_diffs,
-                        ))
+        
+        for name_id, other_catheter in other.catheters_dict.items():
+            catheter = self[name_id]
+            if catheter is None:
+                dict_catheter_diffs[name_id] = other_catheter
+            else:
+                for dwell in catheter.dwells:
+                    for other_dwell in other_catheter.dwells:
+                        if dwell.index == other_dwell.index:
+                            diff_time = dwell.time - other_dwell.time
+                            diff_angle = dwell.angle - other_dwell.angle
+                            diff_relativePos = dwell.relativePos - dwell.relativePos
+                            diff_position = np.zeros(3)
+                            diff_rotation = np.zeros(3)
+                            for i in range(3):
+                                diff_position[i] = dwell.position[i] - other_dwell.position[i]
+                                diff_rotation[i] = dwell.rotation[i] - other_dwell.rotation[i]
+                            # gen dose rate if any attribute other than the dwell time has changed.
+                            diff_gen_doserate = False
+                            if (np.any(diff_position !=0) or np.any(diff_rotation !=0)
+                                or diff_angle != 0):
+                                diff_gen_doserate = True
+                            dwell_diff = DwellPosition(
+                                index=dwell.index,
+                                angle=diff_angle,
+                                position=diff_position,
+                                relativePos=diff_relativePos,
+                                rotation=diff_rotation,
+                                time=diff_time,
+                                gen_dose_rate=diff_gen_doserate,
+                                catheter_index=catheter.index
+                            )
+                            list_dwell_diffs.append(dwell_diff)
+
+                    dict_catheter_diffs[catheter.name_id] = Catheter(
+                        index=catheter.index,
+                        dwells=list_dwell_diffs,
+                        )
         return CatheterTable(
-            catheters_list=list_catheter_diffs,
+            catheters_list=dict_catheter_diffs,
             from_delivered_dwellpositions=self.from_delivered_dwellpositions
         )
 

--- a/brachyutils/geometry/catheter_utils/catheter_table.py
+++ b/brachyutils/geometry/catheter_utils/catheter_table.py
@@ -799,7 +799,7 @@ in the catheters_dict. there is a big bug somewhere in catheter table creation")
             return catheter_found
 
         if isinstance(indices, slice):
-            indices = list(range(*slice.indices(len(self.catheters_dict))))
+            indices = list(range(*indices.indices(len(self.catheters_dict))))
             name_ids = [str(index+1) for index in indices]
             caths_found = {name_id: self.catheters_dict.get(name_id, None) for name_id in name_ids}
             return CatheterTable(

--- a/brachyutils/geometry/catheter_utils/catheter_table.py
+++ b/brachyutils/geometry/catheter_utils/catheter_table.py
@@ -1,6 +1,6 @@
 import copy
 import numpy as np
-from typing import List, Union, Dict, Any, Optional, Tuple, Literal
+from typing import List, Union, Dict, Any, Optional, Tuple, Literal, TYPE_CHECKING
 from pathlib import Path
 from pydantic import BaseModel, computed_field, ConfigDict, model_validator, Field
 import json
@@ -16,11 +16,13 @@ from brachyutils.geometry.catheter_utils.patch_ai_assisted_brachy.catheter_setup
 from brachyutils.geometry.catheter_utils.patch_ai_assisted_brachy.catheter_api import (
     dicom_to_catheter_table, _update_catheter_table, CreatedSetUp
 )
-from brachyutils.dose.dose_utils import BrachyDose
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from tqdm import tqdm
 from collections import defaultdict
 from itertools import chain
+
+if TYPE_CHECKING:
+    from brachyutils.dose.dose_utils import BrachyDose
 
 class ExportConfig_Dose(BaseModel):
     """
@@ -73,7 +75,7 @@ class DwellPosition(BaseModel):
     time: float = 0.0
     catheter_index: int = None
     gen_dose_rate: bool = True
-    dose_rate: BrachyDose = None
+    dose_rate: 'BrachyDose' = None
 
     @model_validator(mode="after")
     def validate_dwell_position(self):
@@ -528,7 +530,7 @@ class CatheterTable(BaseModel):
     catheter_list: List[Catheter] | List[dict] | str | Path | CatheterSetUp | CreatedSetUp
     step_size: float = 5.0
     from_delivered_dwellpositions: bool = False
-    _cached_combined_dose: BrachyDose = None
+    _cached_combined_dose: 'BrachyDose' = None
     _time_diffs:Dict[str, DwellPosition] = None
 
     @computed_field
@@ -606,7 +608,7 @@ class CatheterTable(BaseModel):
         return non_zero_dwell_positions
 
     @computed_field
-    def combined_dose(self) -> BrachyDose:
+    def combined_dose(self) -> 'BrachyDose':
         """
         ### Purpose:
         - To calculate the combined dose by multiplying the dose rates with the dwell times.
@@ -626,6 +628,7 @@ class CatheterTable(BaseModel):
         - self._cached_combined_dose
         also resets self._time_diffs to None for future.
         """
+        from brachyutils.dose.dose_utils import BrachyDose
         all_dwells: List[DwellPosition] = self.all_dwells
         dwells_with_doserate = [dwell for dwell in all_dwells if dwell.dose_rate is not None]
         
@@ -1111,6 +1114,7 @@ class CatheterTable(BaseModel):
             if not pth.exists():
                 raise ValueError(f"Dose rate path ({pth}) does not exist. Either run export or set gen_dose_rate \
 to False for the corresponding dwell position.")
+        from brachyutils.dose.dose_utils import BrachyDose
         dose_rate_dict = defaultdict(BrachyDose)
         if multi_processing:
             with ThreadPoolExecutor(max_workers=16) as executor:
@@ -1405,14 +1409,15 @@ def _load_single_dose_rate(
     pth_dose_rate:Path,
     load_uncertainty=False,
     dtype=np.float32
-    )->BrachyDose:
+    )->'BrachyDose':
+        from brachyutils.dose.dose_utils import BrachyDose
         return BrachyDose(
             pth_dose_file=pth_dose_rate,
             load_uncertainty=load_uncertainty,
             dtype=dtype)
 
 def _write_single_dose_rate(
-    dose_rate:BrachyDose,
+    dose_rate:'BrachyDose',
     dir_export: str | Path = None,
     dose_extension: str = None,
     file_name: str = None,

--- a/brachyutils/geometry/catheter_utils/catheter_table.py
+++ b/brachyutils/geometry/catheter_utils/catheter_table.py
@@ -30,7 +30,7 @@ class DwellPosition(BaseModel):
     - rotation: np.array := rotation of the dwell position in the patient coordinate system [x, y, z]
     - time: float := dwell time for this dwell position
     - weight: float := ratio of this dwell time over the sum of all dwell times in all catheters.
-    
+    - parent_catheter: 
     ### Functions:
     - to_dict() -> dict := convert the dwell position to a dictionary.
     """
@@ -41,6 +41,8 @@ class DwellPosition(BaseModel):
     relativePos: float
     rotation: List[float] | np.array = None
     time: float = 0.0
+    catheter_index: int = None
+    gen_dose_rate: bool = True
 
     @model_validator(mode="after")
     def validate_dwell_position(self):
@@ -48,6 +50,10 @@ class DwellPosition(BaseModel):
         if self.rotation is not None:
             self.rotation = np.array(self.rotation)
         return self
+
+    @computed_field
+    def name_id(self) -> str:
+        return f"C_{self.catheter_index+1}_D_{self.index+1}_A_{self.angle}"
 
     def weight(self, total_time: float) -> float:
         r"""
@@ -78,6 +84,8 @@ class DwellPosition(BaseModel):
             total_time = self.time
         return {
             "index": int(self.index),
+            "name_id": self.name_id,
+            "catheter_index": self.catheter_index,
             "angle": float(self.angle),
             "position": list(self.position),
             "relativePos": float(self.relativePos),

--- a/brachyutils/geometry/catheter_utils/catheter_table.py
+++ b/brachyutils/geometry/catheter_utils/catheter_table.py
@@ -1226,7 +1226,7 @@ agree with the sum of dwells times that have dose rates ({sanity_time})")
                         dose_extension=export_config_dose.file_extension)
         print(f"Dose exported to {dir_export}")
 
-    def update(self, new_catheter_table:"CatheterTable"):
+    def merge(self, new_catheter_table:"CatheterTable"):
         r""" XXX: debug this with the finalized catheter update logic!
         ### Purpose:
         - Given a new catheter table, update self.

--- a/brachyutils/geometry/catheter_utils/catheter_table.py
+++ b/brachyutils/geometry/catheter_utils/catheter_table.py
@@ -508,7 +508,8 @@ class CatheterTable(BaseModel):
         4. from a CatheterSetUp object XXX clean this
         5. from a CreatedSetUp object XXX clean this
     ### Attributes:
-    - catheters_list : List[Catheter] := the list of catheter objects in the catheter table.
+    - catheters_dict : Dict[Catheter] := the dictionary or list of catheter objects in the catheter table.
+    it could also be a string, Path, CatheterSetup, CreatedSetup. We will convert it all to a dictionary.
     - from_delivered_dwellpositions: bool := whether the catheter table was created from delivered 
     dwell positions. only applicable if the catheter table is created from a dicom file.
     If False, the catheter table will be created from the digitization points.
@@ -676,7 +677,7 @@ class CatheterTable(BaseModel):
         - To initialize the CatheterTable object.
         
         ### Inputs:
-        - catheters_list: List[Catheter] | List[dict] | str | Path | CatheterSetUp | CreatedSetUp :=
+        - catheters_dict: List[Catheter] | List[dict] | str | Path | CatheterSetUp | CreatedSetUp :=
         the list of catheter objects in the catheter table or the path to a json or dicom file.
         - step_size: float := the step size in mm between the dwell positions on the catheter table.
         - from_delivered_dwellpositions: bool := if true, the dwell positions inside the delivered dwell positions will be used.
@@ -705,7 +706,7 @@ class CatheterTable(BaseModel):
             self.step_size = cat_dict["step_size"]
 
         elif isinstance(self.catheters_dict, CatheterSetUp):
-            # if the catheters_list is a CatheterSetUp object, convert it to a CatheterTable
+            # if the catheters_dict is a CatheterSetUp object, convert it to a CatheterTable
             cat_setup = self.catheters_dict
             updated_catheter_dict = _update_catheter_table(
                 catheter_table = cat_setup.catheter_table,
@@ -726,7 +727,7 @@ class CatheterTable(BaseModel):
 
         if isinstance(self.catheters_dict[0], dict):
             self.catheters_dict = [
-                Catheter(**catheter_dict) for catheter_dict in self.catheters_list
+                Catheter(**catheter_dict) for catheter_dict in self.catheters_dict
             ]
 
         # if catheter dict is a list, convert it to a dict
@@ -783,7 +784,7 @@ class CatheterTable(BaseModel):
         if self.step_size != other.step_size:
             raise ValueError("Cannot add two catheter tables with different stepsizes.")
         return CatheterTable(
-            catheterlist=self.catheterlist + other.catheterlist,
+            catheters_dict=self.catheter_dict | other.catheter_dict,
             stepsize=self.stepsize,
             from_delivered_dwellpositions=self.from_delivered_dwellpositions,
         )

--- a/brachyutils/geometry/catheter_utils/catheter_table.py
+++ b/brachyutils/geometry/catheter_utils/catheter_table.py
@@ -931,8 +931,21 @@ class CatheterTable(BaseModel):
         catheter.index = new_index
         self.catheters_list[catheter.name_id] = catheter
 
-    def __setitem__(self, name_id: str, new_catheter: dict | Catheter):
-        pass
+    def __setitem__(self, name_id: str, new_catheter: dict | Catheter) -> None:
+        r"""
+        ### Purpose:
+        - To add a new catheter to the catheter table based on its name_id.
+        the name_id = index+1.
+        """
+        if new_catheter.name_id != name_id:
+            raise ValueError("The name_id of the new catheter does not \
+match its index, be sure that the name_id == new_catheter.index +1")
+        if not (isinstance(new_catheter, dict) or isinstance(new_catheter, Catheter)):
+            raise ValueError("The new_catheter should of type dict or Catheter")
+
+        self.catheters_dict[name_id] = (
+            new_catheter if isinstance(new_catheter, Catheter)
+            else Catheter(new_catheter))
 
     def get_dwells_by_name_ids(self, name_ids: List[str]) -> List[DwellPosition]:
         r"""

--- a/brachyutils/geometry/catheter_utils/catheter_table.py
+++ b/brachyutils/geometry/catheter_utils/catheter_table.py
@@ -768,16 +768,17 @@ class CatheterTable(BaseModel):
 
         if isinstance(indices, slice):
             indices = list(range(*slice.indices(len(self.catheters_dict))))
-            caths_found = [cath for cath in self.catheters_list if cath.index in indices]
+            name_ids = [str(index+1) for index in indices]
+            caths_found = {name_id: self.catheter_dict[name_id] for name_id in name_ids}
             return CatheterTable(
                 catheters_dict=caths_found,
                 step_size=self.step_size,
                 from_delivered_dwellpositions=self.from_delivered_dwellpositions,
             )
         elif isinstance(indices, int):
-            if indices < 0 or indices >= len(self.catheters_list):
+            if indices < 0 or indices >= len(self.catheters_dict):
                 return None
-            return self.catheters_list[indices]
+            return self.catheters_dict[f"{indices+1}"]
 
     def __add__(self, other: "CatheterTable") -> "CatheterTable":
         r"""

--- a/brachyutils/geometry/catheter_utils/catheter_table.py
+++ b/brachyutils/geometry/catheter_utils/catheter_table.py
@@ -973,7 +973,7 @@ class CatheterTable(BaseModel):
         """
         treatment_t = self.treatment_time
         return {
-            "catheters_list": [
+            "catheter_list": [
                 catheter.to_dict(total_time=treatment_t) 
                 for catheter in self.catheters_list
                 ],

--- a/brachyutils/geometry/catheter_utils/catheter_table.py
+++ b/brachyutils/geometry/catheter_utils/catheter_table.py
@@ -532,7 +532,8 @@ class CatheterTable(BaseModel):
     ##########
 
     catheters_dict: Union[
-        List[Catheter], List[dict], str, Path, CatheterSetUp, CreatedSetUp,  Dict[Catheter]
+        List[Catheter], List[dict], str, Path, CatheterSetUp, CreatedSetUp,
+        Dict[Catheter], Dict[dict]
     ]
     step_size: float = 5.0
     from_delivered_dwellpositions: bool = False
@@ -725,16 +726,19 @@ class CatheterTable(BaseModel):
             self.step_size = updated_catheter_dict["step_size"]
             self.non_zero_dwell_positions = created_setup.get_non_zero_dwell_positions()
 
-        if isinstance(self.catheters_dict[0], dict):
-            self.catheters_dict = [
-                Catheter(**catheter_dict) for catheter_dict in self.catheters_dict
-            ]
+        elif isinstance(self.catheter_dict, list):
+            # if catheter dict is a list, convert it to a dict
+            real_dict = defaultdict(Catheter)
+            for cat in self.catheter_dict:
+                real_dict[cat.name_id] = cat
+            self.catheter_dict = real_dict
 
-        # if catheter dict is a list, convert it to a dict
-        real_dict = defaultdict(Catheter)
-        for cat in self.catheter_dict:
-            real_dict[cat.name_id] = cat
-        self.catheter_dict = real_dict
+        # check if the values are dicts or catheter\
+        self.catheter_dict = {
+            key: Catheter(val) if isinstance(val, dict) else val
+            for key, val in self.catheter_dict.items()
+        }
+
         return self
 
     def __iter__(self):
@@ -744,21 +748,24 @@ class CatheterTable(BaseModel):
     def __len__(self):
         return len(self.catheters_list)
 
-    def __getitem__(self, indices: int| slice) ->  Union[Catheter, "CatheterTable"] :
+    def __getitem__(self, indices: int | slice | str) ->  Union[Catheter, "CatheterTable"] :
         r"""
         ### Purpose:
         - To get a subset of the catheter table.
 
         ### Inputs:
         - self := the CatheterTable object.
-        - indices: int | slice := the index or slice to get.
+        - indices: int | slice | str := the index, slice or key string to get the 
+        catheters by. index and slice finds the catheters by their catheter.index,
+        while if a string is provided, it'll get the catheters by name_id.
+        note that catheter.name_id = str(catheter.index +1) 
 
         ### Outputs:
         - List[Catheter] := the list of catheters in the catheter table.
         """
         if isinstance(indices, slice):
             return CatheterTable(
-                catheters_list=self.catheters_list[indices],
+                catheters_dict=self.catheters_dict[indices],
                 step_size=self.step_size,
                 from_delivered_dwellpositions=self.from_delivered_dwellpositions,
             )

--- a/brachyutils/geometry/catheter_utils/catheter_table.py
+++ b/brachyutils/geometry/catheter_utils/catheter_table.py
@@ -21,6 +21,7 @@ from concurrent.futures import ThreadPoolExecutor, as_completed
 from tqdm import tqdm
 from collections import defaultdict
 from itertools import chain
+from brachyutils.planning.plan_utils import ExportConfig_Dose
 
 class DwellPosition(BaseModel):
     r"""
@@ -1165,6 +1166,61 @@ agree with the sum of dwells times that have dose rates ({sanity_time})")
         self.combined_dose.uncertainty_image.imageArray = np.sqrt(
         self.combined_dose.uncertainty_image.imageArray)
 
+    def export_dose(
+        self,
+        export_config_dose: ExportConfig_Dose
+    ):
+        r"""
+        ### Purpose:
+        - to export combined dose map and if needed the dose rate maps to a given directory.
+        exporting dose rate maps is optional.
+        ### Inputs:
+        - export_config_dose: The dose export configuration. Look at ExportConfig_Dose for more info 
+        ### Outputs:
+        - None := will export the dose map into the specified export directory.
+        ### Dependencies:
+        - _write_single_dose_rate()
+        - multiprocessing
+        """
+        dir_export = Path(export_config_dose.dir_export)
+        # write combined dose
+        self.combined_dose.write_brachydose_to_file(
+            export_config_dose.pth_combined
+        )
+        if export_config_dose.write_dose_rate_maps:
+            all_dwells = self.all_dwells
+            dose_rate_dict = {
+                dwell.name_id: dwell.dose_rate 
+                for dwell in all_dwells 
+                if dwell.dose_rate is not None}
+
+            if export_config_dose.multi_processing:
+                with ThreadPoolExecutor(max_workers=16) as executor:
+                    futures = {
+                        executor.submit(
+                            _write_single_dose_rate,
+                            self.dose_rate_dict.get(dose_rate_name),
+                            dir_export,
+                            export_config_dose.file_extension,
+                            f"run_{dose_rate_name}"):
+                            dose_rate_name for dose_rate_name in dose_rate_dict
+                        }
+                    for action in tqdm(as_completed(futures), desc="Writing dose rate maps"):
+                        try:
+                            action.result()
+                        except:
+                            failed_path = futures[action]
+                            raise ValueError(f"Failed writing {failed_path}")
+            else:
+                for dwell_name in tqdm(dose_rate_dict, desc="Writing dose rate maps"):
+                    _write_single_dose_rate(
+                        dose_rate=self.dose_rate_dict.get(dwell_name),
+                        dir_export=dir_export,
+                        file_name=f"run_{dwell_name}",
+                        dose_extension=export_config_dose.file_extension)
+        print(f"Dose exported to {dir_export}")
+
+
 def load_delivered_cathetertable_from_dicom(pth_dicom: Path) -> list:
     r"""
     Purpose:
@@ -1250,51 +1306,6 @@ def load_delivered_cathetertable_from_dicom(pth_dicom: Path) -> list:
                 "control_points": control_points,
             }
         )
-
-    def export_dose(
-        self,
-        export_config_dose: ExportConfig_Dose
-    ):
-        r"""
-        ### Purpose:
-        - to export combined dose map and if needed the dose rate maps to a given directory.
-        exporting dose rate maps is optional.
-        ### Inputs:
-        - export_config_dose: The dose export configuration. Look at ExportConfig_Dose for more info 
-        ### Outputs:
-        - None := will export the dose map into the specified export directory.
-        ### Dependencies:
-        - _write_single_dose_rate()
-        - multiprocessing
-        """
-        assert self.combined_dose is not None, "combined dose is not calculated yet"
-        dir_export = Path(export_config_dose.dir_export)
-        # write combined dose
-        self.combined_dose.write_brachydose_to_file(
-            export_config_dose.pth_combined
-        )
-
-        if export_config_dose.write_dose_rate_maps:
-            if export_config_dose.multi_processing:
-                with ThreadPoolExecutor(max_workers=16) as executor:
-                    futures = {
-                        executor.submit(_write_single_dose_rate, self.dose_rate_dict.get(dose_rate_name), dir_export, export_config_dose.file_extension):
-                            dose_rate_name for dose_rate_name in self.dose_rate_dict
-                        }
-                    for action in tqdm(as_completed(futures), desc="Writing dose rate maps"):
-                        try:
-                            action.result()
-                        except:
-                            failed_path = futures[action]
-                            raise ValueError(f"Failed writing {failed_path}")
-            else:
-                for dose_rate in tqdm(self.dose_rate_dict, desc="Writing dose rate maps"):
-                    _write_single_dose_rate(
-                        dose_rate=self.dose_rate_dict.get(dose_rate),
-                        dir_export=dir_export,
-                        dose_extension=export_config_dose.file_extension)
-        print(f"Dose exported to {dir_export}")
-
 
     # # Convert control points to dwell positions:
     # # after extracting the final cummulative time weight of the catheters,

--- a/brachyutils/geometry/catheter_utils/catheter_table.py
+++ b/brachyutils/geometry/catheter_utils/catheter_table.py
@@ -1239,7 +1239,7 @@ agree with the sum of dwells times that have dose rates ({sanity_time})")
         None := update self.
         """
         catheter_table_diff = self - new_catheter_table 
-        time_diffs = {}
+        self._time_diffs = {}
         for catheter_diff in catheter_table_diff:
             # if the catheter is not in the current catheter table, add the entire catheter with all its dwells.
             if self[catheter_diff.index] is None:
@@ -1258,7 +1258,7 @@ agree with the sum of dwells times that have dose rates ({sanity_time})")
                         self[catheter_diff.index][dwell_diff.index].rotation = new_catheter_table[catheter_diff.index][dwell_diff.index].rotation
                         self[catheter_diff.index].gen_dose_rates = True
                     elif dwell_diff.time != 0:
-                        time_diffs[
+                        self.time_diffs[
                             dwell_diff.name_id
                             ] = dwell_diff.time
                     else:

--- a/brachyutils/geometry/catheter_utils/catheter_table.py
+++ b/brachyutils/geometry/catheter_utils/catheter_table.py
@@ -746,7 +746,7 @@ class CatheterTable(BaseModel):
             yield catheter
 
     def __len__(self):
-        return len(self.catheters_list)
+        return len(self.catheters_dict)
 
     def __getitem__(self, indices: int | slice | str) ->  Union[Catheter, "CatheterTable"] :
         r"""

--- a/brachyutils/geometry/catheter_utils/catheter_table.py
+++ b/brachyutils/geometry/catheter_utils/catheter_table.py
@@ -683,10 +683,10 @@ class CatheterTable(BaseModel):
         ### Outputs:
         - CatheterTable := the catheter table object.
         """
-        if (isinstance(self.catheters_list, str) or
-            isinstance(self.catheters_list, Path)
+        if (isinstance(self.catheters_dict, str) or
+            isinstance(self.catheters_dict, Path)
             ):
-            catheter_file = Path(self.catheters_list)
+            catheter_file = Path(self.catheters_dict)
 
             if not catheter_file.exists():
                 raise ValueError(f"catheter file {catheter_file} does not exist.")
@@ -701,12 +701,12 @@ class CatheterTable(BaseModel):
                     pth_dicom=catheter_file,
                     from_delivered_dwellpositions=self.from_delivered_dwellpositions,
                 )
-            self.catheters_list = cat_dict["catheters_list"]
+            self.catheters_dict = cat_dict["catheters_list"]
             self.step_size = cat_dict["step_size"]
 
-        elif isinstance(self.catheters_list, CatheterSetUp):
+        elif isinstance(self.catheters_dict, CatheterSetUp):
             # if the catheters_list is a CatheterSetUp object, convert it to a CatheterTable
-            cat_setup = self.catheters_list
+            cat_setup = self.catheters_dict
             updated_catheter_dict = _update_catheter_table(
                 catheter_table = cat_setup.catheter_table,
                 digitization_points=cat_setup.digitization_points,
@@ -714,20 +714,26 @@ class CatheterTable(BaseModel):
                 tips=cat_setup.get_tips_coords(),
                 step_size=cat_setup.step_size,
             )
-            self.catheters_list = updated_catheter_dict["catheters_list"]
+            self.catheters_dict = updated_catheter_dict["catheters_list"]
             self.step_size = updated_catheter_dict["step_size"]
 
-        elif isinstance(self.catheters_list, CreatedSetUp):
-            created_setup = self.catheters_list
+        elif isinstance(self.catheters_dict, CreatedSetUp):
+            created_setup = self.catheters_dict
             updated_catheter_dict = created_setup.to_brachyutils_CatheterTable_format()
-            self.catheters_list = updated_catheter_dict["catheters_list"]
+            self.catheters_dict = updated_catheter_dict["catheters_list"]
             self.step_size = updated_catheter_dict["step_size"]
             self.non_zero_dwell_positions = created_setup.get_non_zero_dwell_positions()
 
-        if isinstance(self.catheters_list[0], dict):
-            self.catheters_list = [
+        if isinstance(self.catheters_dict[0], dict):
+            self.catheters_dict = [
                 Catheter(**catheter_dict) for catheter_dict in self.catheters_list
             ]
+
+        # if catheter dict is a list, convert it to a dict
+        real_dict = defaultdict(Catheter)
+        for cat in self.catheter_dict:
+            real_dict[cat.name_id] = cat
+        self.catheter_dict = real_dict
         return self
 
     def __iter__(self):

--- a/brachyutils/geometry/catheter_utils/catheter_table.py
+++ b/brachyutils/geometry/catheter_utils/catheter_table.py
@@ -59,7 +59,7 @@ class DwellPosition(BaseModel):
 
     @computed_field
     def name_id(self) -> str:
-        return f"{self.catheter_index+1}_{self.index+1}_{self.angle}"
+        return f"{self.catheter_index+1}{self.index+1}{self.angle}"
 
     def weight(self, total_time: float) -> float:
         r"""
@@ -589,7 +589,7 @@ class CatheterTable(BaseModel):
         - self._time_diffs: a dictionary of time differences for each dwell in the plan. 
         This is used to update the combined dose if the dwell times are updated without
         having to reload the dose rate maps. The keys of the dictionary should be in
-        the format "{catheter.index+1}_{dwell.index+1}_{dwell.angle" and the values
+        the format "{catheter.index+1}{dwell.index+1}{dwell.angle" and the values
         should be the time differences in seconds. If None, the combined dose will
         be calculated using the current dwell times in the plan.
         ### Outputs:
@@ -983,7 +983,7 @@ class CatheterTable(BaseModel):
         if from_delivered_dwellpositions:
             catheter_table_dict = load_delivered_cathetertable_from_dicom(pth_dicom=pth_dicom)
         else:
-            catheter_table_dict, _ = dicom_to_catheter_table(dir_dicom=pth_dicom.parent)
+            catheter_table_dict,  = dicom_to_catheter_table(dir_dicom=pth_dicom.parent)
         return catheter_table_dict
 
     def get_dwell_positions_as_list(self) -> List[List[float]]:
@@ -1117,10 +1117,44 @@ to False for the corresponding dwell position.")
         for dwell in all_dwells:
             dwell.dose_rate = dose_rate_dict.get(dwell.name_id, None)
 
+        # run combined dose to fill out the cached combined dose 
+        self.combined_dose
         if load_uncertainty:
             self._calculate_combined_uncertainty()
         if combined_dose_only:
-            del self.dose_rate_dict
+            for dwell in all_dwells:
+                del dwell.dose_rate
+
+    def _calculate_combined_uncertainty(self):
+        r"""
+        ### Purpose:
+        - To calculate the combined uncertainty of the combined dose map based on the
+        dose rates and dwell times.
+        ### Inputs:
+        - self._cached_combined_dose := the BrachyDose
+        ### Outputs:
+        - Void := will update the self.combined_dose.uncertainty_image
+        """
+        if self._cached_combined_dose is None:
+            raise ValueError("combined dose is not calculated yet")
+
+        treatment_time = self.catheter_table.treatment_time
+        all_dwells = chain.from_iterable(self)
+        dwells_with_doserate = [dwell for dwell in all_dwells if dwell.dose_rate is not None]
+        # sanity check the dwell times matching the treatment time
+        sanity_time = 0
+        for dwell in dwells_with_doserate:
+            sanity_time += dwell.time
+        if sanity_time != treatment_time:
+            raise ValueError(f"The treatment time is {treatment_time}, which does not \
+agree with the sum of dwells times that have dose rates ({sanity_time})")
+        for dwell in dwells_with_doserate:
+            self._cached_combined_dose.uncertainty_image.imageArray.fill(0)
+            self.combined_dose.uncertainty_image.imageArray += (
+                dwell.dose_rate.uncertainty_image.imageArray * (dwell.time/treatment_time)
+                )**2
+        self.combined_dose.uncertainty_image.imageArray = np.sqrt(
+        self.combined_dose.uncertainty_image.imageArray)
 
 def load_delivered_cathetertable_from_dicom(pth_dicom: Path) -> list:
     r"""
@@ -1349,7 +1383,7 @@ def _write_single_dose_rate(
     - dose_rate:= The BrachyDose object for the dose rate data.
     - dir_export:= the directory to which the dose rate maps will be exported
     - file_name:= The name of the file inside dir_export. Following the RapidBrachy standard, it should be
-    "run_{catheter.index+1}_{dwell.index+1}_{angle}.seq.nrrd". if none, dose_rate.path.name is used.
+    "run_{catheter.index+1}{dwell.index+1}{angle}.seq.nrrd". if none, dose_rate.path.name is used.
     - dose_extension := the type of dose rate map to be exported. options are ".3ddose", ".minidos", or ".nrrd"
     ### Output:
     - Void := dose file is written to dir_export+f"/{file_name}.{dose_type}

--- a/brachyutils/geometry/catheter_utils/catheter_table.py
+++ b/brachyutils/geometry/catheter_utils/catheter_table.py
@@ -762,8 +762,11 @@ class CatheterTable(BaseModel):
             raise ValueError("other should be a CatheterTable object.")
         if self.step_size != other.step_size:
             raise ValueError("Cannot add two catheter tables with different stepsizes.")
-        self.catheter_list = self.catheter_list + other.catheter_list
-        return self
+        return CatheterTable(
+            catheterlist=self.catheterlist + other.catheterlist,
+            stepsize=self.stepsize,
+            from_delivered_dwellpositions=self.from_delivered_dwellpositions,
+        )
 
     def __iadd__(self, other: "CatheterTable") -> "CatheterTable":
         r"""
@@ -1229,9 +1232,15 @@ agree with the sum of dwells times that have dose rates ({sanity_time})")
     def merge(self, new_catheter_table:"CatheterTable"):
         r""" XXX: debug this with the finalized catheter update logic!
         ### Purpose:
-        - Given a new catheter table, update self.
-        dose rates are kept only if dwell time is updated. otherwise the 
-        dwells inside a catheter are replaced/deleted.
+        - Given a new catheter table, merge it with self.
+        If a catheter with a specific index does not exist, it'll be added as it is.
+        If a catheter with a specific index exists, then the previous catheter will be updated.
+        Same logic applies to the dwells except that dose rates are kept only if dwell time is updated. 
+        otherwise the dwells inside a catheter are replaced.
+
+        This requires the indecies in the new catheter table to be aware of self. Idealy, we should
+        be using dictionaries, but it's too late at this point.
+
         ### Inputs:
         - new_catheter_table:CatheterTable := The new catheter table used
         to update self.

--- a/brachyutils/geometry/catheter_utils/catheter_table.py
+++ b/brachyutils/geometry/catheter_utils/catheter_table.py
@@ -701,7 +701,7 @@ class CatheterTable(BaseModel):
                     pth_dicom=catheter_file,
                     from_delivered_dwellpositions=self.from_delivered_dwellpositions,
                 )
-            self.catheters_dict = cat_dict["catheters_list"]
+            self.catheters_dict = cat_dict["catheter_list"]
             self.step_size = cat_dict["step_size"]
 
         elif isinstance(self.catheters_dict, CatheterSetUp):
@@ -714,13 +714,13 @@ class CatheterTable(BaseModel):
                 tips=cat_setup.get_tips_coords(),
                 step_size=cat_setup.step_size,
             )
-            self.catheters_dict = updated_catheter_dict["catheters_list"]
+            self.catheters_dict = updated_catheter_dict["catheter_list"]
             self.step_size = updated_catheter_dict["step_size"]
 
         elif isinstance(self.catheters_dict, CreatedSetUp):
             created_setup = self.catheters_dict
             updated_catheter_dict = created_setup.to_brachyutils_CatheterTable_format()
-            self.catheters_dict = updated_catheter_dict["catheters_list"]
+            self.catheters_dict = updated_catheter_dict["catheter_list"]
             self.step_size = updated_catheter_dict["step_size"]
             self.non_zero_dwell_positions = created_setup.get_non_zero_dwell_positions()
 
@@ -1470,14 +1470,14 @@ def load_delivered_cathetertable_from_dicom(pth_dicom: Path) -> list:
         catheter["index"] -= empty_catheter_counter
         final_catheter_table.append(catheter)
     return {
-        "catheters_list": final_catheter_table,
+        "catheter_list": final_catheter_table,
         "treatment_time": treatment_time,
         "step_size": float(
             final_catheter_table[0]["dwells"][1]["relativePos"] 
             - final_catheter_table[0]["dwells"][0]["relativePos"]
             )
     }
-    
+
 def _load_single_dose_rate(
     pth_dose_rate:Path,
     load_uncertainty=False,
@@ -1526,11 +1526,11 @@ def load_from_dicom(
     ### Inputs:
     - pth_dicom: Path := the path to the dicom file containing the catheter table.
     - from_delivered_dwellpositions: bool := if true, the dwell positions inside the 
-    catheters_list will only be the ones with non-zero dwell times. If false, the
+    catheters_dict will only be the ones with non-zero dwell times. If false, the
     dwell positions will be created from the digitization points.
     ### Outputs:
     cat_dict := a dictionary containing the following keys:
-        - catheters_list
+        - catheters_dict
         - step_size
     """
     
@@ -1540,7 +1540,7 @@ def load_from_dicom(
         catheter_table_dict, _ = dicom_to_catheter_table(dir_dicom=pth_dicom.parent)
 
     # add catheter index to the dwells
-    for catheter in catheter_table_dict["catheters_list"]:
+    for catheter in catheter_table_dict["catheter_list"]:
         for dwell in catheter["dwells"]:
             dwell["catheter_index"] = catheter["index"]
 
@@ -1564,7 +1564,7 @@ def load_from_json(pth_json: Path) -> list:
             catheter_table_list = cat_table
             step_size = catheter_table_list[0].get("step_size", None)
         elif isinstance(cat_table, dict):
-            catheter_table_list = cat_table.get("catheters_list", None)
+            catheter_table_list = cat_table.get("catheter_list", None)
             if catheter_table_list is None:
                 catheter_table_dict = cat_table.get("catheters_dict", None)
                 catheter_table_list = list(catheter_table_dict.values())
@@ -1578,7 +1578,7 @@ def load_from_json(pth_json: Path) -> list:
         for catheter_dict in catheter_table_list:
             raw_catheter_table.append(Catheter(**catheter_dict))
         return {
-            "catheters_dict":raw_catheter_table,
+            "catheter_list":raw_catheter_table,
             "step_size":step_size,
             "non_zero_dwell_positions": non_zero_dwell_positions
             }

--- a/brachyutils/geometry/catheter_utils/catheter_table.py
+++ b/brachyutils/geometry/catheter_utils/catheter_table.py
@@ -914,11 +914,6 @@ in the catheters_dict. there is a big bug somewhere in catheter table creation")
                                 self_catheter.dwells[other_dwell.index].position[i] - other_dwell.position[i])
                             diff_rotation[i] = (
                                 self_catheter.dwells[other_dwell.index].rotation[i] - other_dwell.rotation[i])
-                        # gen dose rate if any attribute other than the dwell time has changed.
-                        diff_gen_doserate = False
-                        if (np.any(diff_position !=0) or np.any(diff_rotation !=0)
-                            or diff_angle != 0):
-                            diff_gen_doserate = True
                         dwell_diff = DwellPosition(
                             index=other_dwell.index,
                             angle=diff_angle,
@@ -926,7 +921,8 @@ in the catheters_dict. there is a big bug somewhere in catheter table creation")
                             relativePos=diff_relativePos,
                             rotation=diff_rotation,
                             time=diff_time,
-                            gen_dose_rate=diff_gen_doserate,
+                            # # the decision on whetheter to gen_dose_rate or not is not related to subtraction.
+                            # gen_dose_rate=diff_gen_doserate,
                             catheter_index=other_catheter.index
                         )
                         list_dwell_diffs.append(dwell_diff)
@@ -1378,58 +1374,41 @@ agree with the sum of dwells times that have dose rates ({sanity_time})")
         self._time_diffs = {}
 
         for catheter_diff in catheter_table_diff:
+            new_catheter = new_catheter_table[catheter_diff.name_id]
             self_catheter = self[catheter_diff.name_id]
             if self_catheter is None:
                 # new catheter does not exist, add it to the catheter table
                 # its name_id should be that of new catheter table
-                self[catheter_diff.name_id] = catheter_diff
+                self[catheter_diff.name_id] = new_catheter
                 continue
             else:
-                # new catheter already exists with that name id
-                # update its dwells if needed
-                for dwell_diff in catheter_diff.dwells:
-                    
-                    
-                    
-                    
-                    self_dwell = self.get_dwells_by_name_ids([dwell_diff.name_id])
-                    if len(self_dwell) == 0:
-                        # if this dwell position does not exist, just add it to the catheter
-                        self.set_dwells_by_name_id(
-                            new_catheter_table.get_dwells_by_name_ids([dwell_diff.name_id]).pop())
-                    elif len(self_dwell) == 1:
-                        # the dwell already exists, update it
-                        self.set_dwells_by_name_id(
-                            new_catheter_table.get_dwells_by_name_ids([dwell_diff.name_id]).pop())
-                        # XXX i do not know what's going here. need to think about it
-
-        # identify common catheters
-        # name_ids_diff = [cath.name_id for cath in catheter_table_diff]
-        name_ids_self = [cath.name_id for cath in self]
-        # XXX: debug this with the finalized catheter update logic!
-        for catheter_diff in catheter_table_diff:
-            # if the catheter is not in the current catheter table, add the entire catheter with all its dwells.
-            if catheter_diff.name_id not in name_ids_self:
-                self.append(new_catheter_table[catheter_diff.index])
-                continue
-            for dwell_diff in catheter_diff.dwells:
-                # if that dwell is not in the current cathetr, add it.
-                if self[catheter_diff.index][dwell_diff.index] is None:
-                    self[catheter_diff.index][dwell_diff.index] = new_catheter_table[catheter_diff.index][dwell_diff.index]
+                if self_catheter.num_dwell_positions != catheter_diff.num_dwell_positions:
+                    # if the number of dwell positions does not match self, rewrite the catheter
+                    self[catheter_diff.name_id] = new_catheter
                     continue
                 else:
-                    if np.any(dwell_diff.position != 0) or np.any(dwell_diff.rotation != 0):
-                        # if the postion or rotation of the dwell has changed,
-                        # update it in the catheter table and set gen_dose_rates to True for that catheter.
-                        self[catheter_diff.index][dwell_diff.index].position = new_catheter_table[catheter_diff.index][dwell_diff.index].position
-                        self[catheter_diff.index][dwell_diff.index].rotation = new_catheter_table[catheter_diff.index][dwell_diff.index].rotation
-                        self[catheter_diff.index].gen_dose_rates = True
-                    elif dwell_diff.time != 0:
-                        self.time_diffs[
-                            dwell_diff.name_id
-                            ] = dwell_diff.time
-                    else:
-                        continue
+                    for dwell_diff in catheter_diff.dwells:
+                        self_dwell = self_catheter.dwells[dwell_diff.index]
+                        new_dwell = new_catheter.dwells[dwell_diff.index]
+                        if (np.any(dwell_diff.position !=0) or np.any(dwell_diff.rotation !=0)
+                            or dwell_diff.angle != 0):
+                            new_gen_doserate = True
+                        else:
+                            new_gen_doserate = self_dwell.gen_dose_rate 
+                            self._time_diffs[dwell_diff.name_id] = dwell_diff.time
+                        dwell_attrs_conds = [
+                            ("angle", dwell_diff.angle!=0),
+                            ("position", np.any(dwell_diff.position!=0)),
+                            ("rotation", np.any(dwell_diff.rotation!=0)),
+                            ("relativePos", dwell_diff.relativePos!=0),
+                            ("time", dwell_diff.time!=0),
+                        ]
+                        for attr, cond in dwell_attrs_conds:
+                            if cond:
+                                self_dwell.__setattr__(
+                                    attr,
+                                    new_dwell.__getattribute__(attr))
+                        self_dwell.gen_dose_rate = new_gen_doserate
 
 def load_delivered_cathetertable_from_dicom(pth_dicom: Path) -> list:
     r"""

--- a/brachyutils/geometry/catheter_utils/catheter_table.py
+++ b/brachyutils/geometry/catheter_utils/catheter_table.py
@@ -1354,16 +1354,9 @@ agree with the sum of dwells times that have dose rates ({sanity_time})")
         ### Purpose:
         - Given a new catheter table, merge it with self.
         If a catheter with a specific index does not exist, it'll be added as it is.
-        If a catheter with a specific index exists, then the previous catheter will be updated.
-        Same logic applies to the dwells except that dose rates are kept only if dwell time is updated. 
-        otherwise the dwells inside a catheter are replaced.
-
-        This requires the indecies in the new catheter table to be aware of self. Idealy, we should
-        be using dictionaries, but it's too late at this point.
-        Also, this function assumes that the catheter.index attribute in self matches the the index
-        of the catheter in self.catheters_list, while this assumption is not required for the 
-        new_catheter_table (I know, horrible design choices!)
-
+        If a catheter with a specific index exists but the number of dwell positions do not match, then 
+        the entire catheter will be set from the new catheter table. If a catheter with a specific index
+        exists and the number of dwell positions match then the self catheter will be updated.
         ### Inputs:
         - new_catheter_table:CatheterTable := The new catheter table used
         to update self.

--- a/brachyutils/geometry/catheter_utils/catheter_table.py
+++ b/brachyutils/geometry/catheter_utils/catheter_table.py
@@ -1543,7 +1543,7 @@ def load_from_dicom(
     for catheter in catheter_table_dict["catheters_list"]:
         for dwell in catheter["dwells"]:
             dwell["catheter_index"] = catheter["index"]
-    
+
     return catheter_table_dict
 
 def load_from_json(pth_json: Path) -> list:
@@ -1565,6 +1565,9 @@ def load_from_json(pth_json: Path) -> list:
             step_size = catheter_table_list[0].get("step_size", None)
         elif isinstance(cat_table, dict):
             catheter_table_list = cat_table.get("catheters_list", None)
+            if catheter_table_list is None:
+                catheter_table_dict = cat_table.get("catheters_dict", None)
+                catheter_table_list = list(catheter_table_dict.values())
             step_size = cat_table.get("step_size", None)
             non_zero_dwell_positions = cat_table.get("non_zero_dwell_positions", None)
         else:
@@ -1575,7 +1578,7 @@ def load_from_json(pth_json: Path) -> list:
         for catheter_dict in catheter_table_list:
             raw_catheter_table.append(Catheter(**catheter_dict))
         return {
-            "catheters_list":raw_catheter_table,
+            "catheters_dict":raw_catheter_table,
             "step_size":step_size,
             "non_zero_dwell_positions": non_zero_dwell_positions
             }

--- a/brachyutils/geometry/catheter_utils/catheter_table.py
+++ b/brachyutils/geometry/catheter_utils/catheter_table.py
@@ -204,6 +204,10 @@ class Catheter(BaseModel):
     gen_dose_rates: bool = True
 
     @computed_field
+    def name_id(self) -> str:
+        return f"{self.catheter_index+1}"
+
+    @computed_field
     def channel_total_time(self) -> float:
         r"""
         ### Purpose:
@@ -1249,7 +1253,7 @@ agree with the sum of dwells times that have dose rates ({sanity_time})")
         print(f"Dose exported to {dir_export}")
 
     def merge(self, new_catheter_table:"CatheterTable"):
-        r""" XXX: debug this with the finalized catheter update logic!
+        r"""
         ### Purpose:
         - Given a new catheter table, merge it with self.
         If a catheter with a specific index does not exist, it'll be added as it is.
@@ -1271,6 +1275,8 @@ agree with the sum of dwells times that have dose rates ({sanity_time})")
         """
         catheter_table_diff = self - new_catheter_table
         self._time_diffs = {}
+        name_ids_diff = [cath.name_id for cath in catheter_table_diff]
+        # XXX: debug this with the finalized catheter update logic!
         for catheter_diff in catheter_table_diff:
             # if the catheter is not in the current catheter table, add the entire catheter with all its dwells.
             if self[catheter_diff.index] is None:

--- a/brachyutils/geometry/catheter_utils/catheter_table.py
+++ b/brachyutils/geometry/catheter_utils/catheter_table.py
@@ -1116,6 +1116,7 @@ to False for the corresponding dwell position.")
 
         for dwell in all_dwells:
             dwell.dose_rate = dose_rate_dict.get(dwell.name_id, None)
+            dwell.gen_dose_rate = False
 
         # run combined dose to fill out the cached combined dose 
         self.combined_dose

--- a/brachyutils/geometry/catheter_utils/catheter_table.py
+++ b/brachyutils/geometry/catheter_utils/catheter_table.py
@@ -1370,6 +1370,9 @@ def load_delivered_cathetertable_from_dicom(pth_dicom: Path) -> list:
             for i in range(len(catheter["dwells"])):
                 catheter["dwells"][i]["rotation"] = get_rotation_from_position(i, catheter["dwells"])
         catheter["index"] -= empty_catheter_counter
+        # add catheter index to the dwells
+        for dwell in catheter["dwells"]:
+            dwell["catheter_index"] = catheter["index"]
         final_catheter_table.append(catheter)
     return {
         "catheter_list": final_catheter_table,

--- a/brachyutils/geometry/catheter_utils/catheter_table.py
+++ b/brachyutils/geometry/catheter_utils/catheter_table.py
@@ -330,9 +330,7 @@ class Catheter(BaseModel):
         """
         raise NotImplementedError("This function is not implemented yet.")
 
-    @classmethod
     def get_dwells_from_fit(
-        cls,
         fit_function:PiecewiseLinear3D | NeedleSplineCreator,
         step_size: float = 5.0,
         # kwargs: Dict[str, Any] = None,
@@ -407,8 +405,7 @@ class Catheter(BaseModel):
         """
         return [dwell.get_position() for dwell in self.dwells]
     
-    @classmethod
-    def get_fit_from_points(cls, points:List[List[float]]) -> PiecewiseLinear3D:
+    def get_fit_from_points(points:List[List[float]]) -> PiecewiseLinear3D:
         r"""
         ### Purpose:
         - To generate a spline from a list of points.
@@ -933,8 +930,7 @@ class CatheterTable(BaseModel):
             remove_text=remove_text,
         )
 
-    @classmethod
-    def load_from_json(cls, pth_json: Path) -> list:
+    def load_from_json(pth_json: Path) -> list:
         r"""
         ### Purpose:
         - Load the catheter table from a json file.
@@ -968,9 +964,7 @@ class CatheterTable(BaseModel):
                 "non_zero_dwell_positions": non_zero_dwell_positions
                 }
 
-    @classmethod
     def load_from_dicom(
-        cls,
         pth_dicom: Path,
         from_delivered_dwellpositions: bool = False,
         ) -> Tuple[Dict, Dict]:

--- a/brachyutils/geometry/catheter_utils/catheter_table.py
+++ b/brachyutils/geometry/catheter_utils/catheter_table.py
@@ -1050,7 +1050,7 @@ match its index, be sure that the name_id == new_catheter.index +1")
         """
         dose_gen_list = [cat for cat in self if cat.gen_dose_rates]
         return CatheterTable(
-            catheters_list=dose_gen_list,
+            catheters_dict=dose_gen_list,
             step_size=self.step_size,
             from_delivered_dwellpositions=self.from_delivered_dwellpositions
         )

--- a/brachyutils/geometry/catheter_utils/catheter_table.py
+++ b/brachyutils/geometry/catheter_utils/catheter_table.py
@@ -510,6 +510,14 @@ class CatheterTable(BaseModel):
     _time_diffs:Dict[str, DwellPosition] = None
 
     @computed_field
+    def all_dwells(self) -> List[DwellPosition]:
+        r"""
+        ### Purpose:
+        - returns a list of all the dwell positions in this catheter table.
+        """
+        return chain.from_iterable(self)
+
+    @computed_field
     def treatment_time(self) -> float:
         r"""
         ### Purpose:
@@ -596,7 +604,7 @@ class CatheterTable(BaseModel):
         - self._cached_combined_dose
         also resets self._time_diffs to None for future.
         """
-        all_dwells: List[DwellPosition] = chain.from_iterable(self)
+        all_dwells: List[DwellPosition] = self.all_dwells
         dwells_with_doserate = [dwell for dwell in all_dwells if dwell.dose_rate is not None]
         
         if not dwells_with_doserate:
@@ -1075,7 +1083,7 @@ class CatheterTable(BaseModel):
             raise ValueError(f"directory of dose rates does not exist: {dir_dose_rate}")
 
         # figure out which dwells we want to load dose rates for
-        all_dwells = chain.from_iterable(self)
+        all_dwells = self.all_dwells
         new_dose_rate_files = [
             dir_dose_rate/f"run_{x.name_id}.seq.nrrd" 
             for x in all_dwells if x.gen_dose_rate]
@@ -1140,7 +1148,7 @@ to False for the corresponding dwell position.")
             raise ValueError("combined dose is not calculated yet")
 
         treatment_time = self.catheter_table.treatment_time
-        all_dwells = chain.from_iterable(self)
+        all_dwells = self.all_dwells
         dwells_with_doserate = [dwell for dwell in all_dwells if dwell.dose_rate is not None]
         # sanity check the dwell times matching the treatment time
         sanity_time = 0

--- a/brachyutils/geometry/catheter_utils/catheter_table.py
+++ b/brachyutils/geometry/catheter_utils/catheter_table.py
@@ -1275,11 +1275,13 @@ agree with the sum of dwells times that have dose rates ({sanity_time})")
         """
         catheter_table_diff = self - new_catheter_table
         self._time_diffs = {}
-        name_ids_diff = [cath.name_id for cath in catheter_table_diff]
+        # identify common catheters
+        # name_ids_diff = [cath.name_id for cath in catheter_table_diff]
+        name_ids_self = [cath.name_id for cath in self]
         # XXX: debug this with the finalized catheter update logic!
         for catheter_diff in catheter_table_diff:
             # if the catheter is not in the current catheter table, add the entire catheter with all its dwells.
-            if self[catheter_diff.index] is None:
+            if catheter_diff.name_id not in name_ids_self:
                 self.append(new_catheter_table[catheter_diff.index])
                 continue
             for dwell_diff in catheter_diff.dwells:

--- a/brachyutils/geometry/catheter_utils/catheter_table.py
+++ b/brachyutils/geometry/catheter_utils/catheter_table.py
@@ -899,6 +899,23 @@ class CatheterTable(BaseModel):
                     out_dwells.append(dwell)
         return out_dwells
 
+    def get_catheters_by_ids(self, name_ids: List[str]) -> List[Catheter]:
+        r"""
+        ### Purpose:
+        - To return the catheters that have the queried name ids.
+        The name ids are in the format {catheter.index+1}
+        ### Inputs:
+        - name_ids := The list of name ids to be returned.
+        ### Outputs:
+        - out_catheters : List[Catheter] := The catheters with the matching name ids        
+        """
+        out_catheters = []
+        for name_id in name_ids:
+            for cath in self.catheter_list:
+                if cath.name_id == name_id:
+                    out_catheters.append(cath)
+        return out_catheters
+
     def reset_index(self) -> None:
         r"""
         ### Purpose:
@@ -1242,8 +1259,9 @@ agree with the sum of dwells times that have dose rates ({sanity_time})")
 
         This requires the indecies in the new catheter table to be aware of self. Idealy, we should
         be using dictionaries, but it's too late at this point.
-        Also, this function assumes that the catheter.index attribute matches the the index
-        of the catheter in cathetertable.catheter_list.
+        Also, this function assumes that the catheter.index attribute in self matches the the index
+        of the catheter in self.catheter_list, while this assumption is not required for the 
+        new_catheter_table (I know, horrible design choices!)
 
         ### Inputs:
         - new_catheter_table:CatheterTable := The new catheter table used

--- a/brachyutils/geometry/catheter_utils/catheter_table.py
+++ b/brachyutils/geometry/catheter_utils/catheter_table.py
@@ -805,8 +805,10 @@ class CatheterTable(BaseModel):
     def __sub__(self, other: "CatheterTable") -> "CatheterTable":
         r"""
         ### Purpose:
-        - To subtract the dwell times, position and 
-        rotation of one catheter table from the current catheter table.
+        - To subtract the dwell times, position and rotation of one catheter table
+        from the current catheter table. This subtraction excludes the dose rates.
+        gen_dose_rate is set to true if the position, rotation or angle has changed.
+
         ### Inputs:
         - self := the current CatheterTable object.
         - other := the CatheterTable object to be subtracted.
@@ -838,7 +840,7 @@ class CatheterTable(BaseModel):
                                 # gen dose rate if any attribute other than the dwell time has changed.
                                 diff_gen_doserate = False
                                 if (np.any(diff_position !=0) or np.any(diff_rotation !=0)
-                                    or diff_angle != 0 or diff_relativePos != 0):
+                                    or diff_angle != 0):
                                     diff_gen_doserate = True
                                 dwell_diff = DwellPosition(
                                     index=dwell.index,
@@ -1240,6 +1242,8 @@ agree with the sum of dwells times that have dose rates ({sanity_time})")
 
         This requires the indecies in the new catheter table to be aware of self. Idealy, we should
         be using dictionaries, but it's too late at this point.
+        Also, this function assumes that the catheter.index attribute matches the the index
+        of the catheter in cathetertable.catheter_list.
 
         ### Inputs:
         - new_catheter_table:CatheterTable := The new catheter table used
@@ -1247,7 +1251,7 @@ agree with the sum of dwells times that have dose rates ({sanity_time})")
         ### Output:
         None := update self.
         """
-        catheter_table_diff = self - new_catheter_table 
+        catheter_table_diff = self - new_catheter_table
         self._time_diffs = {}
         for catheter_diff in catheter_table_diff:
             # if the catheter is not in the current catheter table, add the entire catheter with all its dwells.

--- a/brachyutils/geometry/catheter_utils/catheter_table.py
+++ b/brachyutils/geometry/catheter_utils/catheter_table.py
@@ -891,29 +891,29 @@ in the catheters_dict. there is a big bug somewhere in catheter table creation")
         list_dwell_diffs = []
         
         for name_id, other_catheter in other.catheters_dict.items():
-            catheter = self[name_id]
-            if catheter is None:
+            self_catheter = self[name_id]
+            if self_catheter is None:
                 dict_catheter_diffs[name_id] = other_catheter
             else:
-                if catheter.num_dwell_positions != other_catheter.num_dwell_positions:
+                if self_catheter.num_dwell_positions != other_catheter.num_dwell_positions:
                     # if the number of dwell positions differs, put the entire other catheter
                     # in the difference!
                     dict_catheter_diffs[name_id] = other_catheter
                 else:
                     for other_dwell in other_catheter.dwells:
                         #  take the diff between the dwells with the same index.
-                        diff_time = catheter.dwells[other_dwell.index].time - other_dwell.time
-                        diff_angle = catheter.dwells[other_dwell.index].angle - other_dwell.angle
+                        diff_time = self_catheter.dwells[other_dwell.index].time - other_dwell.time
+                        diff_angle = self_catheter.dwells[other_dwell.index].angle - other_dwell.angle
                         diff_relativePos = (
-                            catheter.dwells[other_dwell.index].relativePos
-                            - catheter.dwells[other_dwell.index].relativePos)
+                            self_catheter.dwells[other_dwell.index].relativePos
+                            - self_catheter.dwells[other_dwell.index].relativePos)
                         diff_position = np.zeros(3)
                         diff_rotation = np.zeros(3)
                         for i in range(3):
                             diff_position[i] = (
-                                catheter.dwells[other_dwell.index].position[i] - other_dwell.position[i])
+                                self_catheter.dwells[other_dwell.index].position[i] - other_dwell.position[i])
                             diff_rotation[i] = (
-                                catheter.dwells[other_dwell.index].rotation[i] - other_dwell.rotation[i])
+                                self_catheter.dwells[other_dwell.index].rotation[i] - other_dwell.rotation[i])
                         # gen dose rate if any attribute other than the dwell time has changed.
                         diff_gen_doserate = False
                         if (np.any(diff_position !=0) or np.any(diff_rotation !=0)
@@ -927,14 +927,13 @@ in the catheters_dict. there is a big bug somewhere in catheter table creation")
                             rotation=diff_rotation,
                             time=diff_time,
                             gen_dose_rate=diff_gen_doserate,
-                            catheter_index=catheter.index
+                            catheter_index=other_catheter.index
                         )
                         list_dwell_diffs.append(dwell_diff)
 
-                    dict_catheter_diffs[catheter.name_id] = Catheter(
-                        index=catheter.index,
-                        dwells=list_dwell_diffs,
-                        )
+                    dict_catheter_diffs[other_catheter.name_id] = Catheter(
+                        index=other_catheter.index,
+                        dwells=list_dwell_diffs)
         return CatheterTable(
             catheters_list=dict_catheter_diffs,
             from_delivered_dwellpositions=self.from_delivered_dwellpositions
@@ -1386,7 +1385,6 @@ agree with the sum of dwells times that have dose rates ({sanity_time})")
                 self[catheter_diff.name_id] = catheter_diff
                 continue
             else:
-                    
                 # new catheter already exists with that name id
                 # update its dwells if needed
                 for dwell_diff in catheter_diff.dwells:

--- a/brachyutils/geometry/catheter_utils/catheter_table.py
+++ b/brachyutils/geometry/catheter_utils/catheter_table.py
@@ -680,9 +680,9 @@ class CatheterTable(BaseModel):
                 raise NotImplementedError("this feature is not implemented yet.")
 
             if str(catheter_file).endswith(".json"):
-                cat_dict = self.load_from_json(catheter_file)
+                cat_dict = load_from_json(catheter_file)
             elif str(catheter_file).endswith(".dcm"):
-                cat_dict = self.load_from_dicom(
+                cat_dict = load_from_dicom(
                     pth_dicom=catheter_file,
                     from_delivered_dwellpositions=self.from_delivered_dwellpositions,
                 )
@@ -955,65 +955,6 @@ class CatheterTable(BaseModel):
             one_markup_per_catheter=one_markup_per_catheter,
             remove_text=remove_text,
         )
-
-    def load_from_json(pth_json: Path) -> list:
-        r"""
-        ### Purpose:
-        - Load the catheter table from a json file.
-        
-        ### Inputs:
-        - pth_json: Path := the path to the json file containing the catheter table.
-        
-        ### Outputs:
-        - Void := will update the catheter table based on the json file.
-        """
-        raw_catheter_table: list = []
-        with open(pth_json, "r") as json_file:
-            cat_table = json.load(json_file)
-            if isinstance(cat_table, list):
-                catheter_table_list = cat_table
-                step_size = catheter_table_list[0].get("step_size", None)
-            elif isinstance(cat_table, dict):
-                catheter_table_list = cat_table.get("catheter_list", None)
-                step_size = cat_table.get("step_size", None)
-                non_zero_dwell_positions = cat_table.get("non_zero_dwell_positions", None)
-            else:
-                raise ValueError(f"contents of the catheter file {pth_json} should be a list or dictionary")
-            if catheter_table_list is None:
-                raise ValueError(f"catheter list is missing from file {pth_json}")
-
-            for catheter_dict in catheter_table_list:
-                raw_catheter_table.append(Catheter(**catheter_dict))
-            return {
-                "catheter_list":raw_catheter_table,
-                "step_size":step_size,
-                "non_zero_dwell_positions": non_zero_dwell_positions
-                }
-
-    def load_from_dicom(
-        pth_dicom: Path,
-        from_delivered_dwellpositions: bool = False,
-        ) -> Tuple[Dict, Dict]:
-        r"""
-        ### Purpose:
-        - Load the catheter table from a dicom file.
-
-        ### Inputs:
-        - pth_dicom: Path := the path to the dicom file containing the catheter table.
-        - from_delivered_dwellpositions: bool := if true, the dwell positions inside the 
-        catheter_list will only be the ones with non-zero dwell times. If false, the
-        dwell positions will be created from the digitization points.
-        ### Outputs:
-        cat_dict := a dictionary containing the following keys:
-            - catheter_list
-            - step_size
-        """
-        
-        if from_delivered_dwellpositions:
-            catheter_table_dict = load_delivered_cathetertable_from_dicom(pth_dicom=pth_dicom)
-        else:
-            catheter_table_dict,  = dicom_to_catheter_table(dir_dicom=pth_dicom.parent)
-        return catheter_table_dict
 
     def get_dwell_positions_as_list(self) -> List[List[float]]:
         r"""
@@ -1440,3 +1381,62 @@ def _write_single_dose_rate(
     dir_export = Path(dir_export)
     pth_out = dir_export/(file_name+dose_extension)
     dose_rate.write_brachydose_to_file(pth_dose_file=pth_out)
+
+def load_from_dicom(
+    pth_dicom: Path,
+    from_delivered_dwellpositions: bool = False,
+    ) -> Tuple[Dict, Dict]:
+    r"""
+    ### Purpose:
+    - Load the catheter table from a dicom file.
+
+    ### Inputs:
+    - pth_dicom: Path := the path to the dicom file containing the catheter table.
+    - from_delivered_dwellpositions: bool := if true, the dwell positions inside the 
+    catheter_list will only be the ones with non-zero dwell times. If false, the
+    dwell positions will be created from the digitization points.
+    ### Outputs:
+    cat_dict := a dictionary containing the following keys:
+        - catheter_list
+        - step_size
+    """
+    
+    if from_delivered_dwellpositions:
+        catheter_table_dict = load_delivered_cathetertable_from_dicom(pth_dicom=pth_dicom)
+    else:
+        catheter_table_dict,  = dicom_to_catheter_table(dir_dicom=pth_dicom.parent)
+    return catheter_table_dict
+
+def load_from_json(pth_json: Path) -> list:
+    r"""
+    ### Purpose:
+    - Load the catheter table from a json file.
+    
+    ### Inputs:
+    - pth_json: Path := the path to the json file containing the catheter table.
+    
+    ### Outputs:
+    - Void := will update the catheter table based on the json file.
+    """
+    raw_catheter_table: list = []
+    with open(pth_json, "r") as json_file:
+        cat_table = json.load(json_file)
+        if isinstance(cat_table, list):
+            catheter_table_list = cat_table
+            step_size = catheter_table_list[0].get("step_size", None)
+        elif isinstance(cat_table, dict):
+            catheter_table_list = cat_table.get("catheter_list", None)
+            step_size = cat_table.get("step_size", None)
+            non_zero_dwell_positions = cat_table.get("non_zero_dwell_positions", None)
+        else:
+            raise ValueError(f"contents of the catheter file {pth_json} should be a list or dictionary")
+        if catheter_table_list is None:
+            raise ValueError(f"catheter list is missing from file {pth_json}")
+
+        for catheter_dict in catheter_table_list:
+            raw_catheter_table.append(Catheter(**catheter_dict))
+        return {
+            "catheter_list":raw_catheter_table,
+            "step_size":step_size,
+            "non_zero_dwell_positions": non_zero_dwell_positions
+            }

--- a/brachyutils/geometry/catheter_utils/catheter_table.py
+++ b/brachyutils/geometry/catheter_utils/catheter_table.py
@@ -760,14 +760,10 @@ class CatheterTable(BaseModel):
         """
         if not isinstance(other, CatheterTable):
             raise ValueError("other should be a CatheterTable object.")
-        combined_catheter_list = self.catheter_list + other.catheter_list
-        combined_step_size = max(self.step_size, other.step_size)
-        new_cat_table =  CatheterTable(
-            catheter_list=combined_catheter_list,
-            step_size=combined_step_size,
-        )
-        new_cat_table.reset_index()
-        return new_cat_table
+        if self.step_size != other.step_size:
+            raise ValueError("Cannot add two catheter tables with different stepsizes.")
+        self.catheter_list = self.catheter_list + other.catheter_list
+        return self
 
     def __iadd__(self, other: "CatheterTable") -> "CatheterTable":
         r"""
@@ -784,8 +780,8 @@ class CatheterTable(BaseModel):
         if not isinstance(other, CatheterTable):
             raise ValueError("other should be a CatheterTable object.")
         self.catheter_list += other.catheter_list
-        self.step_size = max(self.step_size, other.step_size)
-        self.reset_index()
+        if self.step_size != other.step_size:
+            raise ValueError("Cannot add two catheter tables with different stepsizes.")
         return self
 
     def __delitem__(self, index: int | slice):

--- a/brachyutils/geometry/catheter_utils/catheter_table.py
+++ b/brachyutils/geometry/catheter_utils/catheter_table.py
@@ -67,7 +67,7 @@ class DwellPosition(BaseModel):
     """
     model_config = ConfigDict(arbitrary_types_allowed=True)
     index: int
-    angle: float = 0.0
+    angle: int = 0
     position: List[float] | np.array
     relativePos: float
     rotation: List[float] | np.array = None
@@ -85,7 +85,7 @@ class DwellPosition(BaseModel):
 
     @computed_field
     def name_id(self) -> str:
-        return f"{self.catheter_index+1}{self.index+1}{self.angle}"
+        return f"{self.catheter_index+1}_{self.index+1}_{self.angle}"
 
     def weight(self, total_time: float) -> float:
         r"""
@@ -538,7 +538,7 @@ class CatheterTable(BaseModel):
         ### Purpose:
         - returns a list of all the dwell positions in this catheter table.
         """
-        return chain.from_iterable(self)
+        return list(chain.from_iterable(self))
 
     @computed_field
     def treatment_time(self) -> float:
@@ -1181,7 +1181,6 @@ agree with the sum of dwells times that have dose rates ({sanity_time})")
                         file_name=f"run_{dwell_name}",
                         dose_extension=export_config_dose.file_extension)
         print(f"Dose exported to {dir_export}")
-
 
 def load_delivered_cathetertable_from_dicom(pth_dicom: Path) -> list:
     r"""

--- a/brachyutils/geometry/catheter_utils/catheter_table.py
+++ b/brachyutils/geometry/catheter_utils/catheter_table.py
@@ -352,12 +352,12 @@ class Catheter(BaseModel):
         r"""
         ### Purpose:
         - Insert a dwell position to the catheter and update the necessary attributes.
-
+        XXX need to check if relativePos is correct. for now, just append the dwell 
         ### Inputs:
         - self := the Catheter object.
         - dwell:DwellPosition := the dwell position to be added.
         """
-        raise NotImplementedError("This function is not implemented yet.")
+        self.dwells.append(dwell)
 
     def get_dwells_from_fit(
         fit_function:PiecewiseLinear3D | NeedleSplineCreator,
@@ -766,7 +766,9 @@ class CatheterTable(BaseModel):
         if isinstance(indices, str):
             catheter_found = self.catheters_dict.get(indices, None)
             # make sure that the catheter.index and the indicies match
-            if indices != catheter_found.name_id:
+            if catheter_found is None:
+                return None
+            elif indices != catheter_found.name_id:
                 raise ValueError("The index of the catheter found and the name_id do not match \
 in the catheters_dict. there is a big bug somewhere in catheter table creation")
             return catheter_found
@@ -968,6 +970,16 @@ match its index, be sure that the name_id == new_catheter.index +1")
                 if dwell.name_id == name_id:
                     out_dwells.append(dwell)
         return out_dwells
+
+    def set_dwells_by_name_id(self, new_dwell: DwellPosition):
+        r"""
+        ### Purpose:
+        - To set the dwell on the right catheter by their name id.
+        If the dwell already exists, its fields should be updated accordingly.
+        If the change is only in dwell time and nothing else, the change in dwell time is recorded in
+        self._time_diff
+        """
+        pass
 
     def get_catheters_by_ids(self, name_ids: List[str]) -> List[Catheter]:
         r"""
@@ -1342,6 +1354,29 @@ agree with the sum of dwells times that have dose rates ({sanity_time})")
         """
         catheter_table_diff = self - new_catheter_table
         self._time_diffs = {}
+        
+        for catheter_diff in catheter_table_diff:
+            self_catheter = self[catheter_diff.name_id]
+            if self_catheter is None:
+                # new catheter does not exist, add it to the catheter table
+                # its name_id should be that of new catheter table
+                self[catheter_diff.name_id] = catheter_diff
+                continue
+            else:
+                # new catheter already exists with that name id
+                # update its dwells if needed
+                for dwell_diff in catheter_diff.dwells:
+                    self_dwell = self.get_dwells_by_name_ids([dwell_diff.name_id])
+                    if len(self_dwell) == 0:
+                        # if this dwell position does not exist, just add it to the catheter
+                        self.set_dwells_by_name_id(
+                            new_catheter_table.get_dwells_by_name_ids([dwell_diff.name_id]).pop())
+                    elif len(self_dwell) == 1:
+                        # the dwell already exists, update it
+                        self.set_dwells_by_name_id(
+                            new_catheter_table.get_dwells_by_name_ids([dwell_diff.name_id]).pop())
+                        # XXX i do not know what's going here. need to think about it
+
         # identify common catheters
         # name_ids_diff = [cath.name_id for cath in catheter_table_diff]
         name_ids_self = [cath.name_id for cath in self]

--- a/brachyutils/geometry/catheter_utils/catheter_table.py
+++ b/brachyutils/geometry/catheter_utils/catheter_table.py
@@ -816,10 +816,10 @@ class CatheterTable(BaseModel):
         """
         if not isinstance(other, CatheterTable):
             raise ValueError("other should be a CatheterTable object.")
-        new_cat_table = copy.deepcopy(self)
+        # new_cat_table = copy.deepcopy(self)
         #if len(new_cat_table) != len(other):
         #    raise ValueError("The two catheter tables should have the same number of catheters to be subtracted.")
-        for catheter in new_cat_table.catheter_list:
+        for catheter in self.catheter_list:
             for other_catheter in other.catheter_list:
                 if catheter.index == other_catheter.index:
                     #if len(catheter.dwells) != len(other_catheter.dwells):
@@ -831,8 +831,8 @@ class CatheterTable(BaseModel):
                                 for i in range(3):
                                     dwell.position[i] = dwell.position[i] - other_dwell.position[i]
                                     dwell.rotation[i] = dwell.rotation[i] - other_dwell.rotation[i]
-        return new_cat_table
-    
+        return self
+
     def append(self, catheter: Catheter) -> None:
         r"""
         ### Purpose:

--- a/brachyutils/geometry/catheter_utils/catheter_table.py
+++ b/brachyutils/geometry/catheter_utils/catheter_table.py
@@ -1,8 +1,8 @@
 import copy
 import numpy as np
-from typing import List, Union, Dict, Any, Optional, Tuple
+from typing import List, Union, Dict, Any, Optional, Tuple, Literal
 from pathlib import Path
-from pydantic import BaseModel, computed_field, ConfigDict, model_validator
+from pydantic import BaseModel, computed_field, ConfigDict, model_validator, Field
 import json
 import SimpleITK as sitk
 from opentps.core.processing.imageProcessing.sitkImageProcessing import imageToSITK
@@ -21,7 +21,31 @@ from concurrent.futures import ThreadPoolExecutor, as_completed
 from tqdm import tqdm
 from collections import defaultdict
 from itertools import chain
-from brachyutils.planning.plan_utils import ExportConfig_Dose
+
+class ExportConfig_Dose(BaseModel):
+    """
+    Configuration for exporting dose data from the plan.
+    """
+    model_config = ConfigDict(
+        arbitrary_types_allowed=True,
+        use_attribute_docstrings=True  # Enables auto-docs from Field desc [web:48]
+    )
+    dir_export: str | Path = Field(None, description="Directory where dose files are exported.")
+    name_combined: str = Field("combined", description="File name for combined dose output.")
+    file_extension: Literal[".seq.nrrd", ".3ddose"] = Field(
+        ".seq.nrrd", description="Allowed file extensions for dose files."
+    )
+    write_dose_rate_maps: bool = Field(
+        False, description="Whether to write individual dose rate maps to files."
+    )
+    multi_processing: bool = Field(
+        True, description="Enable multiprocessing for export (yes/no toggle)."
+    )
+    @computed_field
+    def pth_combined(self)->Path:
+        self.dir_export = Path(self.dir_export)
+        return self.dir_export/(self.name_combined+self.file_extension)
+
 
 class DwellPosition(BaseModel):
     r"""

--- a/brachyutils/geometry/catheter_utils/catheter_table.py
+++ b/brachyutils/geometry/catheter_utils/catheter_table.py
@@ -93,7 +93,7 @@ class DwellPosition(BaseModel):
             "time": float(self.time),
             "weight": float(self.weight(total_time)),
         }
-    
+
     def get_position(self) -> List[float]:
         r"""
         ### Purpose:
@@ -106,7 +106,7 @@ class DwellPosition(BaseModel):
         - List[float] := the position of the dwell position.
         """
         return self.position
-    
+
     def isin_mask(self, mask:Union[ROIMask, sitk.Image]) -> bool:
         r"""
         ### Purpose:

--- a/brachyutils/geometry/catheter_utils/catheter_table.py
+++ b/brachyutils/geometry/catheter_utils/catheter_table.py
@@ -16,6 +16,7 @@ from brachyutils.geometry.catheter_utils.patch_ai_assisted_brachy.catheter_setup
 from brachyutils.geometry.catheter_utils.patch_ai_assisted_brachy.catheter_api import (
     dicom_to_catheter_table, _update_catheter_table, CreatedSetUp
 )
+from brachyutils.dose.dose_utils import BrachyDose
 
 class DwellPosition(BaseModel):
     r"""
@@ -43,6 +44,7 @@ class DwellPosition(BaseModel):
     time: float = 0.0
     catheter_index: int = None
     gen_dose_rate: bool = True
+    dose_rate: BrachyDose = None
 
     @model_validator(mode="after")
     def validate_dwell_position(self):
@@ -53,7 +55,7 @@ class DwellPosition(BaseModel):
 
     @computed_field
     def name_id(self) -> str:
-        return f"C_{self.catheter_index+1}_D_{self.index+1}_A_{self.angle}"
+        return f"{self.catheter_index+1}_{self.index+1}_{self.angle}"
 
     def weight(self, total_time: float) -> float:
         r"""

--- a/brachyutils/geometry/catheter_utils/catheter_table.py
+++ b/brachyutils/geometry/catheter_utils/catheter_table.py
@@ -600,7 +600,8 @@ class CatheterTable(BaseModel):
         dwells_with_doserate = [dwell for dwell in all_dwells if dwell.dose_rate is not None]
         
         if not dwells_with_doserate:
-            return self._cached_combined_dose
+            # return self._cached_combined_dose
+            raise ValueError("No dose rate found in this catheter table")
 
         # Initialize combined dose if not cached
         if self._cached_combined_dose is None:
@@ -842,6 +843,7 @@ class CatheterTable(BaseModel):
             step_size=self.step_size,
             from_delivered_dwellpositions=self.from_delivered_dwellpositions
         )
+
     def to_dict(self) -> dict:
         r"""
         ### Purpose:
@@ -860,6 +862,7 @@ class CatheterTable(BaseModel):
             "step_size": float(self.step_size),
             "treatment_time": float(treatment_t)
         }
+
     def info(self) -> None:
         r"""
         ### Purpose:
@@ -1045,6 +1048,7 @@ class CatheterTable(BaseModel):
         load_uncertainty:bool=False,
         multi_processing: bool = True,
         combined_dose_only: bool = False,
+        dose_dtype=np.float32,
         ):
         r"""
         ### Purpose:
@@ -1072,8 +1076,9 @@ class CatheterTable(BaseModel):
 
         # figure out which dwells we want to load dose rates for
         all_dwells = chain.from_iterable(self)
-        all_dwells = [f"run_{x.name_id}.seq.nrrd" for x in all_dwells if x.gen_dose_rate]
-        new_dose_rate_files = [dir_dose_rate/pth_dwell for pth_dwell in all_dwells]
+        new_dose_rate_files = [
+            dir_dose_rate/f"run_{x.name_id}.seq.nrrd" 
+            for x in all_dwells if x.gen_dose_rate]
         # check if the paths are correct
         for pth in new_dose_rate_files:
             if not pth.exists():
@@ -1083,7 +1088,7 @@ to False for the corresponding dwell position.")
         if multi_processing:
             with ThreadPoolExecutor(max_workers=16) as executor:
                 futures = {
-                    executor.submit(_load_single_dose_rate, pth, load_uncertainty): pth
+                    executor.submit(_load_single_dose_rate, pth, load_uncertainty, dose_dtype): pth
                     for pth in new_dose_rate_files
                     }
                 for action in tqdm(
@@ -1104,14 +1109,14 @@ to False for the corresponding dwell position.")
                 total=len(new_dose_rate_files)):
                 dose_rate = _load_single_dose_rate(
                     pth_dose_rate=pth,
-                    load_uncertainty=load_uncertainty)
+                    load_uncertainty=load_uncertainty,
+                    dtype=dose_dtype)
                 dwell_id = dose_rate.path.name.split(".")[0].split("run_")[1]
                 dose_rate_dict[dwell_id] = dose_rate
 
         for dwell in all_dwells:
-            dwell.dose_rate = dose_rate_dict[dwell.name_id]
+            dwell.dose_rate = dose_rate_dict.get(dwell.name_id, None)
 
-        self._calculate_combined_dose()
         if load_uncertainty:
             self._calculate_combined_uncertainty()
         if combined_dose_only:
@@ -1323,9 +1328,13 @@ def load_delivered_cathetertable_from_dicom(pth_dicom: Path) -> list:
     
 def _load_single_dose_rate(
     pth_dose_rate:Path,
-    load_uncertainty=False
+    load_uncertainty=False,
+    dtype=np.float32
     )->BrachyDose:
-        return BrachyDose(pth_dose_file=pth_dose_rate, load_uncertainty=load_uncertainty)
+        return BrachyDose(
+            pth_dose_file=pth_dose_rate,
+            load_uncertainty=load_uncertainty,
+            dtype=dtype)
 
 def _write_single_dose_rate(
     dose_rate:BrachyDose,

--- a/brachyutils/geometry/catheter_utils/catheter_table.py
+++ b/brachyutils/geometry/catheter_utils/catheter_table.py
@@ -285,8 +285,9 @@ class Catheter(BaseModel):
             )
         elif (self.tip_position is not None and self.last_dwell_coordinate is not None):
             # Create fit and dwells from tip and last dwell coordinates
+            points=[self.tip_position, self.last_dwell_coordinate]
             self.fit_function = self.get_fit_from_points(
-                points=[self.tip_position, self.last_dwell_coordinate]
+                points=points
             )
             self.dwells = self.get_dwells_from_fit(
                 fit_function=self.fit_function,
@@ -372,6 +373,7 @@ class Catheter(BaseModel):
         self.dwells.append(dwell)
 
     def get_dwells_from_fit(
+        self,
         fit_function:PiecewiseLinear3D | NeedleSplineCreator,
         step_size: float = 5.0,
         # kwargs: Dict[str, Any] = None,
@@ -446,7 +448,7 @@ class Catheter(BaseModel):
         """
         return [dwell.get_position() for dwell in self.dwells]
     
-    def get_fit_from_points(points:List[List[float]]) -> PiecewiseLinear3D:
+    def get_fit_from_points(self, points:List[List[float]]) -> PiecewiseLinear3D:
         r"""
         ### Purpose:
         - To generate a spline from a list of points.
@@ -609,18 +611,6 @@ class CatheterTable(BaseModel):
         - int := the number of dwell positions in the catheter table.
         """
         return len(self.all_dwells)
-
-    @computed_field
-    def num_catheters(self) -> int:
-        r"""
-        ### Purpose:
-        - To calculate the number of catheters
-        ### Inputs:
-        - self := the Catheter object.
-        ### Outputs:
-        - int := the number of dwell positions in the catheter.
-        """
-        return len(self.catheters_dict)
 
     @computed_field
     def non_zero_dwell_positions(

--- a/brachyutils/geometry/catheter_utils/catheter_table.py
+++ b/brachyutils/geometry/catheter_utils/catheter_table.py
@@ -1002,7 +1002,7 @@ match its index, be sure that the name_id == new_catheter.index +1")
 
     def get_catheters_for_dose_gen(self):
         r"""
-        ### Purpose:
+        ### Purpose: XXX: we probably do not need this if we use gen_dose_rate for dwells
         - To get a catheter table with only the catheters that are needed for dose rate generation
         """
         dose_gen_list = [cat for cat in self if cat.gen_dose_rates]
@@ -1023,7 +1023,7 @@ match its index, be sure that the name_id == new_catheter.index +1")
         """
         treatment_t = self.treatment_time
         return {
-            "catheter_list": [
+            "catheter_list": [ # only change this after adapting seb's functions to use catheters_dict
                 catheter.to_dict(total_time=treatment_t) 
                 for catheter in self.catheters_list
                 ],
@@ -1037,10 +1037,10 @@ match its index, be sure that the name_id == new_catheter.index +1")
         - To print the information about the catheter table.
         """
         print("Catheter table info is as follows:")
-        print(f"Number of catheters: {len(self.catheters_list)}")
+        print(f"Number of catheters: {self.num_catheters}")
         print(f"Total treatment time: {self.treatment_time}")
         for catheter in self.catheters_list:
-            print(f"Catheter ID: {catheter.index}")
+            print(f"Catheter Name ID (index+1): {catheter.name_id}")
             print(f"Number of dwell positions: {len(catheter.dwells)}")
             print(f"Total channel time: {catheter.channel_total_time}")
 
@@ -1103,6 +1103,7 @@ match its index, be sure that the name_id == new_catheter.index +1")
         ### Outputs:
         - List[List[float]] := the list of dwell positions from all catheters.
         """
+        raise DeprecationWarning("please use all_dwells() instead")
         dwell_positions = []
         for catheter in self.catheters_list:
             dwell_positions.extend(catheter.get_dwell_positions_as_list())
@@ -1127,7 +1128,7 @@ match its index, be sure that the name_id == new_catheter.index +1")
 
         for catheter in self.catheters_list:
             catheter.remove_inside_mask(mask)
-        
+
     def remove_outside_mask(self, mask:Union[ROIMask, sitk.Image], margin_mm: float = 0.0) -> None:
         r"""
         ### Purpose:

--- a/brachyutils/geometry/catheter_utils/catheter_table.py
+++ b/brachyutils/geometry/catheter_utils/catheter_table.py
@@ -221,6 +221,18 @@ class Catheter(BaseModel):
         """
         return np.sum([dwell.time for dwell in self.dwells])
 
+    @computed_field
+    def num_dwell_positions(self) -> int:
+        r"""
+        ### Purpose:
+        - To calculate the number of dwell position in a catheter
+        ### Inputs:
+        - self := the Catheter object.        
+        ### Outputs:
+        - int := the number of dwell positions in the catheter.
+        """
+        return len(self.dwells)
+
     @model_validator(mode="after")
     def validate_catheter(self):
         r"""
@@ -596,7 +608,7 @@ class CatheterTable(BaseModel):
         ### Outputs:
         - int := the number of dwell positions in the catheter table.
         """
-        return np.sum([len(catheter.dwells) for catheter in self.catheters_list])
+        return len(self.all_dwells)
 
     @computed_field
     def non_zero_dwell_positions(
@@ -860,7 +872,10 @@ in the catheters_dict. there is a big bug somewhere in catheter table creation")
         - To take the difference between self and other catheter table. If a catheter in the
         other catheter table does not exist in self (name_id) not found, the entire catheter 
         will be included in the difference. If the other catheter exists in self, the dwell times,
-        position and rotation of that catheter is subtracted from from the self catheter.
+        position and rotation of the dwell positions of that catheter are subtracted from
+        the self catheter. If the number of dwells do not match in a catheter, then the entire
+        catheter will be included in the difference.
+        Please note that we dwells with the same indicies are subtracted.
         This subtraction excludes the dose rates.
         gen_dose_rate is set to true if the position, rotation or angle has changed.
 
@@ -880,33 +895,41 @@ in the catheters_dict. there is a big bug somewhere in catheter table creation")
             if catheter is None:
                 dict_catheter_diffs[name_id] = other_catheter
             else:
-                for dwell in catheter.dwells:
+                if catheter.num_dwell_positions != other_catheter.num_dwell_positions:
+                    # if the number of dwell positions differs, put the entire other catheter
+                    # in the difference!
+                    dict_catheter_diffs[name_id] = other_catheter
+                else:
                     for other_dwell in other_catheter.dwells:
-                        if dwell.index == other_dwell.index:
-                            diff_time = dwell.time - other_dwell.time
-                            diff_angle = dwell.angle - other_dwell.angle
-                            diff_relativePos = dwell.relativePos - dwell.relativePos
-                            diff_position = np.zeros(3)
-                            diff_rotation = np.zeros(3)
-                            for i in range(3):
-                                diff_position[i] = dwell.position[i] - other_dwell.position[i]
-                                diff_rotation[i] = dwell.rotation[i] - other_dwell.rotation[i]
-                            # gen dose rate if any attribute other than the dwell time has changed.
-                            diff_gen_doserate = False
-                            if (np.any(diff_position !=0) or np.any(diff_rotation !=0)
-                                or diff_angle != 0):
-                                diff_gen_doserate = True
-                            dwell_diff = DwellPosition(
-                                index=dwell.index,
-                                angle=diff_angle,
-                                position=diff_position,
-                                relativePos=diff_relativePos,
-                                rotation=diff_rotation,
-                                time=diff_time,
-                                gen_dose_rate=diff_gen_doserate,
-                                catheter_index=catheter.index
-                            )
-                            list_dwell_diffs.append(dwell_diff)
+                        #  take the diff between the dwells with the same index.
+                        diff_time = catheter.dwells[other_dwell.index].time - other_dwell.time
+                        diff_angle = catheter.dwells[other_dwell.index].angle - other_dwell.angle
+                        diff_relativePos = (
+                            catheter.dwells[other_dwell.index].relativePos
+                            - catheter.dwells[other_dwell.index].relativePos)
+                        diff_position = np.zeros(3)
+                        diff_rotation = np.zeros(3)
+                        for i in range(3):
+                            diff_position[i] = (
+                                catheter.dwells[other_dwell.index].position[i] - other_dwell.position[i])
+                            diff_rotation[i] = (
+                                catheter.dwells[other_dwell.index].rotation[i] - other_dwell.rotation[i])
+                        # gen dose rate if any attribute other than the dwell time has changed.
+                        diff_gen_doserate = False
+                        if (np.any(diff_position !=0) or np.any(diff_rotation !=0)
+                            or diff_angle != 0):
+                            diff_gen_doserate = True
+                        dwell_diff = DwellPosition(
+                            index=other_dwell.index,
+                            angle=diff_angle,
+                            position=diff_position,
+                            relativePos=diff_relativePos,
+                            rotation=diff_rotation,
+                            time=diff_time,
+                            gen_dose_rate=diff_gen_doserate,
+                            catheter_index=catheter.index
+                        )
+                        list_dwell_diffs.append(dwell_diff)
 
                     dict_catheter_diffs[catheter.name_id] = Catheter(
                         index=catheter.index,
@@ -1354,7 +1377,7 @@ agree with the sum of dwells times that have dose rates ({sanity_time})")
         """
         catheter_table_diff = self - new_catheter_table
         self._time_diffs = {}
-        
+
         for catheter_diff in catheter_table_diff:
             self_catheter = self[catheter_diff.name_id]
             if self_catheter is None:
@@ -1363,9 +1386,14 @@ agree with the sum of dwells times that have dose rates ({sanity_time})")
                 self[catheter_diff.name_id] = catheter_diff
                 continue
             else:
+                    
                 # new catheter already exists with that name id
                 # update its dwells if needed
                 for dwell_diff in catheter_diff.dwells:
+                    
+                    
+                    
+                    
                     self_dwell = self.get_dwells_by_name_ids([dwell_diff.name_id])
                     if len(self_dwell) == 0:
                         # if this dwell position does not exist, just add it to the catheter

--- a/brachyutils/geometry/catheter_utils/catheter_table.py
+++ b/brachyutils/geometry/catheter_utils/catheter_table.py
@@ -506,6 +506,8 @@ class CatheterTable(BaseModel):
     catheter_list: List[Catheter] | List[dict] | str | Path | CatheterSetUp | CreatedSetUp
     step_size: float = 5.0
     from_delivered_dwellpositions: bool = False
+    _cached_combined_dose: BrachyDose = None
+    _time_diffs:Dict[str, DwellPosition] = None
 
     @computed_field
     def treatment_time(self) -> float:
@@ -572,6 +574,52 @@ class CatheterTable(BaseModel):
                     dwell_positions.append(dwell.position)
             non_zero_dwell_positions[f"Needle_{catheter.index}"] = dwell_positions
         return non_zero_dwell_positions
+
+    @computed_field
+    def combined_dose(self) -> BrachyDose:
+        """
+        ### Purpose:
+        - To calculate the combined dose by multiplying the dose rates with the dwell times.
+        if this value has already been cached without change to the catheter table, then
+        the cache will be returned.
+        We require strict name matching between the _time_diffs and dwell.name_id
+        ### Inputs:
+        - self._cached_combined_dose: The combined dose caclualted previously, which will 
+        be returned if no change to the catheter table has been made.
+        - self._time_diffs: a dictionary of time differences for each dwell in the plan. 
+        This is used to update the combined dose if the dwell times are updated without
+        having to reload the dose rate maps. The keys of the dictionary should be in
+        the format "{catheter.index+1}_{dwell.index+1}_{dwell.angle" and the values
+        should be the time differences in seconds. If None, the combined dose will
+        be calculated using the current dwell times in the plan.
+        ### Outputs:
+        - self._cached_combined_dose
+        also resets self._time_diffs to None for future.
+        """
+        all_dwells: List[DwellPosition] = chain.from_iterable(self)
+        dwells_with_doserate = [dwell for dwell in all_dwells if dwell.dose_rate is not None]
+        
+        if not dwells_with_doserate:
+            return self._cached_combined_dose
+
+        # Initialize combined dose if not cached
+        if self._cached_combined_dose is None:
+            self._cached_combined_dose = BrachyDose.dose_with_empty_grid_like(
+            dwells_with_doserate[0].dose_rate
+            )
+
+        # Calculate combined dose with or without time diffs
+        for dwell in dwells_with_doserate:
+            dwell_time = (
+            self._time_diffs.get(dwell.name_id, 0) 
+            if self._time_diffs is not None 
+            else dwell.time
+            )
+            if dwell_time != 0:
+                self._cached_combined_dose.dose_image.imageArray += dwell.dose_rate * dwell_time
+        # reset the time diffs for future
+        self._time_diffs = None
+        return self._cached_combined_dose
 
     @model_validator(mode="after")
     def validate_catheter_table(self):
@@ -1018,40 +1066,20 @@ class CatheterTable(BaseModel):
         if self.num_dwell_positions == 0:
             raise ValueError("Cannot load dose rates since there is no catheters or dwells in this catheter table.")
 
-        pth_dose_rate = Path(dir_dose_rate).resolve()
-        if not pth_dose_rate.exists():
-            raise ValueError(f"directory of dose rates does not exist: {pth_dose_rate}")
+        dir_dose_rate = Path(dir_dose_rate).resolve()
+        if not dir_dose_rate.exists():
+            raise ValueError(f"directory of dose rates does not exist: {dir_dose_rate}")
 
         # figure out which dwells we want to load dose rates for
-        all_dwells = self.
-        
-        dose_rate_files = list(pth_dose_rate.glob("run_*.seq.nrrd"))
-
-        # if len(dose_rate_files) > self.num_dwell_positions:
-        #     raise ValueError("Cannot have more dose rates than dwells for a catheter table.")
-
-        new_dose_rate_files = []
-        # load file if they have not been loaded since modification
-        for pth in dose_rate_files:
-            # check if pth is not needed in catheter table skip it:
-            cat_index_from_pth, dwell_index_from_pth = pth.name.split("_")[1:3]
-            cat_index_from_pth, dwell_index_from_pth = int(cat_index_from_pth)-1, int(dwell_index_from_pth)-1
-            if 0 <= cat_index_from_pth < len(self):
-                dwells = self[cat_index_from_pth].dwells
-                if 0 <= dwell_index_from_pth < len(dwells):
-                    pass
-                else:
-                    continue
-            else:
-                continue
-
-            if not self.dose_rate_dict.get(pth.name, None):
-                new_dose_rate_files.append(pth)
-            elif pth.stat().st_mtime != self.dose_rate_dict.get(pth.name).modification_time:
-                new_dose_rate_files.append(pth)
-            else:
-                continue
-
+        all_dwells = chain.from_iterable(self)
+        all_dwells = [f"run_{x.name_id}.seq.nrrd" for x in all_dwells if x.gen_dose_rate]
+        new_dose_rate_files = [dir_dose_rate/pth_dwell for pth_dwell in all_dwells]
+        # check if the paths are correct
+        for pth in new_dose_rate_files:
+            if not pth.exists():
+                raise ValueError(f"Dose rate path ({pth}) does not exist. Either run export or set gen_dose_rate \
+to False for the corresponding dwell position.")
+        dose_rate_dict = defaultdict(BrachyDose)
         if multi_processing:
             with ThreadPoolExecutor(max_workers=16) as executor:
                 futures = {
@@ -1064,7 +1092,8 @@ class CatheterTable(BaseModel):
                     total=len(new_dose_rate_files)):
                     try:
                         dose_rate = action.result()
-                        self.dose_rate_dict[dose_rate.path.name] = dose_rate
+                        dwell_id = dose_rate.path.name.split(".")[0].split("run_")[1]
+                        dose_rate_dict[dwell_id] = dose_rate
                     except:
                         failed_path = futures[action]
                         raise ValueError(f"Failed loading f{failed_path}")
@@ -1077,15 +1106,10 @@ class CatheterTable(BaseModel):
                     pth_dose_rate=pth,
                     load_uncertainty=load_uncertainty)
                 dwell_id = dose_rate.path.name.split(".")[0].split("run_")[1]
-                self.dose_rate_dict[dwell_id] = dose_rate
+                dose_rate_dict[dwell_id] = dose_rate
 
-        # now sort dose rates according to increasing catheter name and shield numbers
-        # Fastest and most compact version
-        sorted_items = sorted(
-            self.dose_rate_dict.items(),
-            key=lambda f: tuple(map(int, f[0].removeprefix('run_').removesuffix('.seq.nrrd').split('_')))
-        )
-        self.dose_rate_dict = defaultdict(BrachyDose, sorted_items)
+        for dwell in all_dwells:
+            dwell.dose_rate = dose_rate_dict[dwell.name_id]
 
         self._calculate_combined_dose()
         if load_uncertainty:

--- a/brachyutils/geometry/catheter_utils/catheter_table.py
+++ b/brachyutils/geometry/catheter_utils/catheter_table.py
@@ -582,7 +582,7 @@ class CatheterTable(BaseModel):
         ### Outputs:
         - int := the number of catheters in the catheter table.
         """
-        return len(self.catheter_dict)
+        return len(self.catheters_dict)
     
     @computed_field
     def num_dwell_positions(self) -> int:
@@ -726,17 +726,17 @@ class CatheterTable(BaseModel):
             self.step_size = updated_catheter_dict["step_size"]
             self.non_zero_dwell_positions = created_setup.get_non_zero_dwell_positions()
 
-        elif isinstance(self.catheter_dict, list):
+        elif isinstance(self.catheters_dict, list):
             # if catheter dict is a list, convert it to a dict
             real_dict = defaultdict(Catheter)
-            for cat in self.catheter_dict:
+            for cat in self.catheters_dict:
                 real_dict[cat.name_id] = cat
-            self.catheter_dict = real_dict
+            self.catheters_dict = real_dict
 
         # check if the values are dicts or catheter\
-        self.catheter_dict = {
+        self.catheters_dict = {
             key: Catheter(val) if isinstance(val, dict) else val
-            for key, val in self.catheter_dict.items()
+            for key, val in self.catheters_dict.items()
         }
 
         return self
@@ -769,7 +769,7 @@ class CatheterTable(BaseModel):
         if isinstance(indices, slice):
             indices = list(range(*slice.indices(len(self.catheters_dict))))
             name_ids = [str(index+1) for index in indices]
-            caths_found = {name_id: self.catheter_dict[name_id] for name_id in name_ids}
+            caths_found = {name_id: self.catheters_dict[name_id] for name_id in name_ids}
             return CatheterTable(
                 catheters_dict=caths_found,
                 step_size=self.step_size,
@@ -797,7 +797,7 @@ class CatheterTable(BaseModel):
         if self.step_size != other.step_size:
             raise ValueError("Cannot add two catheter tables with different stepsizes.")
         return CatheterTable(
-            catheters_dict=self.catheter_dict | other.catheter_dict,
+            catheters_dict=self.catheters_dict | other.catheters_dict,
             stepsize=self.stepsize,
             from_delivered_dwellpositions=self.from_delivered_dwellpositions,
         )

--- a/brachyutils/geometry/catheter_utils/catheter_table.py
+++ b/brachyutils/geometry/catheter_utils/catheter_table.py
@@ -227,7 +227,7 @@ class Catheter(BaseModel):
         ### Purpose:
         - To calculate the number of dwell position in a catheter
         ### Inputs:
-        - self := the Catheter object.        
+        - self := the Catheter object.
         ### Outputs:
         - int := the number of dwell positions in the catheter.
         """
@@ -611,6 +611,18 @@ class CatheterTable(BaseModel):
         return len(self.all_dwells)
 
     @computed_field
+    def num_catheters(self) -> int:
+        r"""
+        ### Purpose:
+        - To calculate the number of catheters
+        ### Inputs:
+        - self := the Catheter object.
+        ### Outputs:
+        - int := the number of dwell positions in the catheter.
+        """
+        return len(self.catheters_dict)
+
+    @computed_field
     def non_zero_dwell_positions(
         self,
         ) -> Dict[str, List[List[float]]]:
@@ -738,18 +750,19 @@ class CatheterTable(BaseModel):
             self.step_size = updated_catheter_dict["step_size"]
             self.non_zero_dwell_positions = created_setup.get_non_zero_dwell_positions()
 
-        elif isinstance(self.catheters_dict, list):
+        if isinstance(self.catheters_dict, list):
             # if catheter dict is a list, convert it to a dict
             real_dict = defaultdict(Catheter)
             for cat in self.catheters_dict:
-                real_dict[cat.name_id] = cat
+                cat_obj = Catheter(**cat) if isinstance(cat, dict) else cat
+                real_dict[cat_obj.name_id] = cat_obj
             self.catheters_dict = real_dict
 
         # check if the values are dicts or catheter\
-        self.catheters_dict = {
-            key: Catheter(val) if isinstance(val, dict) else val
-            for key, val in self.catheters_dict.items()
-        }
+        # self.catheters_dict = {
+        #     key: Catheter(val) if isinstance(val, dict) else val
+        #     for key, val in self.catheters_dict.items()
+        # }
 
         return self
 

--- a/brachyutils/geometry/catheter_utils/catheter_table.py
+++ b/brachyutils/geometry/catheter_utils/catheter_table.py
@@ -764,7 +764,12 @@ class CatheterTable(BaseModel):
         - List[Catheter] := the list of catheters in the catheter table.
         """
         if isinstance(indices, str):
-            return self.catheters_dict.get(indices, None)
+            catheter_found = self.catheters_dict.get(indices, None)
+            # make sure that the catheter.index and the indicies match
+            if indices != catheter_found.name_id:
+                raise ValueError("The index of the catheter found and the name_id do not match \
+in the catheters_dict. there is a big bug somewhere in catheter table creation")
+            return catheter_found
 
         if isinstance(indices, slice):
             indices = list(range(*slice.indices(len(self.catheters_dict))))

--- a/brachyutils/geometry/catheter_utils/catheter_table.py
+++ b/brachyutils/geometry/catheter_utils/catheter_table.py
@@ -877,7 +877,7 @@ class CatheterTable(BaseModel):
         catheter.index = new_index
         self.catheter_list.append(catheter)
 
-    def get_dwell_by_name_ids(self, name_ids: List[str]) -> List[DwellPosition]:
+    def get_dwells_by_name_ids(self, name_ids: List[str]) -> List[DwellPosition]:
         r"""
         ### Purpose:
         - To return dwell positions that have the queried name ids.

--- a/brachyutils/geometry/catheter_utils/catheter_table.py
+++ b/brachyutils/geometry/catheter_utils/catheter_table.py
@@ -1,6 +1,6 @@
 import copy
 import numpy as np
-from typing import List, Union, Dict, Any, Optional, Tuple, Literal, TYPE_CHECKING
+from typing import List, Union, Dict, Any, Optional, Tuple, Literal
 from pathlib import Path
 from pydantic import BaseModel, computed_field, ConfigDict, model_validator, Field
 import json
@@ -21,8 +21,7 @@ from tqdm import tqdm
 from collections import defaultdict
 from itertools import chain
 
-if TYPE_CHECKING:
-    from brachyutils.dose.dose_utils import BrachyDose
+from brachyutils.dose.dose_utils import BrachyDose
 
 class ExportConfig_Dose(BaseModel):
     """

--- a/brachyutils/geometry/catheter_utils/catheter_table.py
+++ b/brachyutils/geometry/catheter_utils/catheter_table.py
@@ -508,7 +508,7 @@ class CatheterTable(BaseModel):
         4. from a CatheterSetUp object XXX clean this
         5. from a CreatedSetUp object XXX clean this
     ### Attributes:
-    - catheter_list : List[Catheter] := the list of catheter objects in the catheter table.
+    - catheters_list : List[Catheter] := the list of catheter objects in the catheter table.
     - from_delivered_dwellpositions: bool := whether the catheter table was created from delivered 
     dwell positions. only applicable if the catheter table is created from a dicom file.
     If False, the catheter table will be created from the digitization points.
@@ -530,7 +530,9 @@ class CatheterTable(BaseModel):
     model_config = ConfigDict(arbitrary_types_allowed=True)
     ##########
 
-    catheter_list: List[Catheter] | List[dict] | str | Path | CatheterSetUp | CreatedSetUp
+    catheters_dict: Union[
+        List[Catheter], List[dict], str, Path, CatheterSetUp, CreatedSetUp,  Dict[Catheter]
+    ]
     step_size: float = 5.0
     from_delivered_dwellpositions: bool = False
     _cached_combined_dose: 'BrachyDose' = None
@@ -545,6 +547,14 @@ class CatheterTable(BaseModel):
         return list(chain.from_iterable(self))
 
     @computed_field
+    def catheters_list(self) -> List[Catheter]:
+        r"""
+        ### Purpose:
+        - returns a list of catheters from self.catheters_dict
+        """
+        return list(self.catheters_dict.values())
+
+    @computed_field
     def treatment_time(self) -> float:
         r"""
         ### Purpose:
@@ -556,7 +566,7 @@ class CatheterTable(BaseModel):
         ### Outputs:
         - float := the total treatment time.
         """
-        return np.sum([catheter.channel_total_time for catheter in self.catheter_list])
+        return np.sum([catheter.channel_total_time for catheter in self.catheters_list])
 
     @computed_field
     def num_catheters(self) -> int:
@@ -570,7 +580,7 @@ class CatheterTable(BaseModel):
         ### Outputs:
         - int := the number of catheters in the catheter table.
         """
-        return len(self.catheter_list)
+        return len(self.catheter_dict)
     
     @computed_field
     def num_dwell_positions(self) -> int:
@@ -584,7 +594,7 @@ class CatheterTable(BaseModel):
         ### Outputs:
         - int := the number of dwell positions in the catheter table.
         """
-        return np.sum([len(catheter.dwells) for catheter in self.catheter_list])
+        return np.sum([len(catheter.dwells) for catheter in self.catheters_list])
 
     @computed_field
     def non_zero_dwell_positions(
@@ -602,7 +612,7 @@ class CatheterTable(BaseModel):
         dwell positions that were actually used for plan delivery.
         """
         non_zero_dwell_positions = {}
-        for catheter in self.catheter_list:
+        for catheter in self.catheters_list:
             dwell_positions = []
             for dwell in catheter.dwells:
                 if dwell.time > 0.0:
@@ -666,17 +676,17 @@ class CatheterTable(BaseModel):
         - To initialize the CatheterTable object.
         
         ### Inputs:
-        - catheter_list: List[Catheter] | List[dict] | str | Path | CatheterSetUp | CreatedSetUp :=
+        - catheters_list: List[Catheter] | List[dict] | str | Path | CatheterSetUp | CreatedSetUp :=
         the list of catheter objects in the catheter table or the path to a json or dicom file.
         - step_size: float := the step size in mm between the dwell positions on the catheter table.
         - from_delivered_dwellpositions: bool := if true, the dwell positions inside the delivered dwell positions will be used.
         ### Outputs:
         - CatheterTable := the catheter table object.
         """
-        if (isinstance(self.catheter_list, str) or
-            isinstance(self.catheter_list, Path)
+        if (isinstance(self.catheters_list, str) or
+            isinstance(self.catheters_list, Path)
             ):
-            catheter_file = Path(self.catheter_list)
+            catheter_file = Path(self.catheters_list)
 
             if not catheter_file.exists():
                 raise ValueError(f"catheter file {catheter_file} does not exist.")
@@ -691,12 +701,12 @@ class CatheterTable(BaseModel):
                     pth_dicom=catheter_file,
                     from_delivered_dwellpositions=self.from_delivered_dwellpositions,
                 )
-            self.catheter_list = cat_dict["catheter_list"]
+            self.catheters_list = cat_dict["catheters_list"]
             self.step_size = cat_dict["step_size"]
 
-        elif isinstance(self.catheter_list, CatheterSetUp):
-            # if the catheter_list is a CatheterSetUp object, convert it to a CatheterTable
-            cat_setup = self.catheter_list
+        elif isinstance(self.catheters_list, CatheterSetUp):
+            # if the catheters_list is a CatheterSetUp object, convert it to a CatheterTable
+            cat_setup = self.catheters_list
             updated_catheter_dict = _update_catheter_table(
                 catheter_table = cat_setup.catheter_table,
                 digitization_points=cat_setup.digitization_points,
@@ -704,28 +714,28 @@ class CatheterTable(BaseModel):
                 tips=cat_setup.get_tips_coords(),
                 step_size=cat_setup.step_size,
             )
-            self.catheter_list = updated_catheter_dict["catheter_list"]
+            self.catheters_list = updated_catheter_dict["catheters_list"]
             self.step_size = updated_catheter_dict["step_size"]
 
-        elif isinstance(self.catheter_list, CreatedSetUp):
-            created_setup = self.catheter_list
+        elif isinstance(self.catheters_list, CreatedSetUp):
+            created_setup = self.catheters_list
             updated_catheter_dict = created_setup.to_brachyutils_CatheterTable_format()
-            self.catheter_list = updated_catheter_dict["catheter_list"]
+            self.catheters_list = updated_catheter_dict["catheters_list"]
             self.step_size = updated_catheter_dict["step_size"]
             self.non_zero_dwell_positions = created_setup.get_non_zero_dwell_positions()
 
-        if isinstance(self.catheter_list[0], dict):
-            self.catheter_list = [
-                Catheter(**catheter_dict) for catheter_dict in self.catheter_list
+        if isinstance(self.catheters_list[0], dict):
+            self.catheters_list = [
+                Catheter(**catheter_dict) for catheter_dict in self.catheters_list
             ]
         return self
 
     def __iter__(self):
-        for catheter in self.catheter_list:
+        for catheter in self.catheters_list:
             yield catheter
 
     def __len__(self):
-        return len(self.catheter_list)
+        return len(self.catheters_list)
 
     def __getitem__(self, indices: int| slice) ->  Union[Catheter, "CatheterTable"] :
         r"""
@@ -741,14 +751,14 @@ class CatheterTable(BaseModel):
         """
         if isinstance(indices, slice):
             return CatheterTable(
-                catheter_list=self.catheter_list[indices],
+                catheters_list=self.catheters_list[indices],
                 step_size=self.step_size,
                 from_delivered_dwellpositions=self.from_delivered_dwellpositions,
             )
         elif isinstance(indices, int):
-            if indices < 0 or indices >= len(self.catheter_list):
+            if indices < 0 or indices >= len(self.catheters_list):
                 return None
-            return self.catheter_list[indices]
+            return self.catheters_list[indices]
 
     def __add__(self, other: "CatheterTable") -> "CatheterTable":
         r"""
@@ -786,7 +796,7 @@ class CatheterTable(BaseModel):
         """
         if not isinstance(other, CatheterTable):
             raise ValueError("other should be a CatheterTable object.")
-        self.catheter_list += other.catheter_list
+        self.catheters_list += other.catheters_list
         if self.step_size != other.step_size:
             raise ValueError("Cannot add two catheter tables with different stepsizes.")
         return self
@@ -803,7 +813,7 @@ class CatheterTable(BaseModel):
         ### Outputs:
         - None
         """
-        del self.catheter_list[index]
+        del self.catheters_list[index]
         self.reset_index()
 
     def __sub__(self, other: "CatheterTable") -> "CatheterTable":
@@ -825,8 +835,8 @@ class CatheterTable(BaseModel):
         list_dwell_diffs = []
         #if len(new_cat_table) != len(other):
         #    raise ValueError("The two catheter tables should have the same number of catheters to be subtracted.")
-        for catheter in self.catheter_list:
-            for other_catheter in other.catheter_list:
+        for catheter in self.catheters_list:
+            for other_catheter in other.catheters_list:
                 if catheter.index == other_catheter.index:
                     #if len(catheter.dwells) != len(other_catheter.dwells):
                     #    raise ValueError("The two catheters should have the same number of dwell positions to be subtracted.")
@@ -864,7 +874,7 @@ class CatheterTable(BaseModel):
                             dwells=list_dwell_diffs,
                         ))
         return CatheterTable(
-            catheter_list=list_catheter_diffs,
+            catheters_list=list_catheter_diffs,
             from_delivered_dwellpositions=self.from_delivered_dwellpositions
         )
 
@@ -882,9 +892,9 @@ class CatheterTable(BaseModel):
         """
         if not isinstance(catheter, Catheter):
             raise ValueError("catheter should be a Catheter object.")
-        new_index = len(self.catheter_list)
+        new_index = len(self.catheters_list)
         catheter.index = new_index
-        self.catheter_list.append(catheter)
+        self.catheters_list.append(catheter)
 
     def get_dwells_by_name_ids(self, name_ids: List[str]) -> List[DwellPosition]:
         r"""
@@ -915,7 +925,7 @@ class CatheterTable(BaseModel):
         """
         out_catheters = []
         for name_id in name_ids:
-            for cath in self.catheter_list:
+            for cath in self.catheters_list:
                 if cath.name_id == name_id:
                     out_catheters.append(cath)
         return out_catheters
@@ -931,7 +941,7 @@ class CatheterTable(BaseModel):
         ### Outputs:
         - None
         """
-        for i, catheter in enumerate(self.catheter_list):
+        for i, catheter in enumerate(self.catheters_list):
             catheter.index = i
 
     def get_catheters_for_dose_gen(self):
@@ -941,7 +951,7 @@ class CatheterTable(BaseModel):
         """
         dose_gen_list = [cat for cat in self if cat.gen_dose_rates]
         return CatheterTable(
-            catheter_list=dose_gen_list,
+            catheters_list=dose_gen_list,
             step_size=self.step_size,
             from_delivered_dwellpositions=self.from_delivered_dwellpositions
         )
@@ -957,9 +967,9 @@ class CatheterTable(BaseModel):
         """
         treatment_t = self.treatment_time
         return {
-            "catheter_list": [
+            "catheters_list": [
                 catheter.to_dict(total_time=treatment_t) 
-                for catheter in self.catheter_list
+                for catheter in self.catheters_list
                 ],
             "step_size": float(self.step_size),
             "treatment_time": float(treatment_t)
@@ -971,9 +981,9 @@ class CatheterTable(BaseModel):
         - To print the information about the catheter table.
         """
         print("Catheter table info is as follows:")
-        print(f"Number of catheters: {len(self.catheter_list)}")
+        print(f"Number of catheters: {len(self.catheters_list)}")
         print(f"Total treatment time: {self.treatment_time}")
-        for catheter in self.catheter_list:
+        for catheter in self.catheters_list:
             print(f"Catheter ID: {catheter.index}")
             print(f"Number of dwell positions: {len(catheter.dwells)}")
             print(f"Total channel time: {catheter.channel_total_time}")
@@ -1038,7 +1048,7 @@ class CatheterTable(BaseModel):
         - List[List[float]] := the list of dwell positions from all catheters.
         """
         dwell_positions = []
-        for catheter in self.catheter_list:
+        for catheter in self.catheters_list:
             dwell_positions.extend(catheter.get_dwell_positions_as_list())
         return dwell_positions
 
@@ -1059,7 +1069,7 @@ class CatheterTable(BaseModel):
         if margin_mm > 0.0:
             mask = dilate_mask_in_mm(mask, margin_mm, voxel_based=False)
 
-        for catheter in self.catheter_list:
+        for catheter in self.catheters_list:
             catheter.remove_inside_mask(mask)
         
     def remove_outside_mask(self, mask:Union[ROIMask, sitk.Image], margin_mm: float = 0.0) -> None:
@@ -1079,7 +1089,7 @@ class CatheterTable(BaseModel):
         if margin_mm > 0.0:
             mask = dilate_mask_in_mm(mask, margin_mm, voxel_based=False)
 
-        for catheter in self.catheter_list:
+        for catheter in self.catheters_list:
             catheter.remove_outside_mask(mask)
 
     def load_dose_rates(
@@ -1264,7 +1274,7 @@ agree with the sum of dwells times that have dose rates ({sanity_time})")
         This requires the indecies in the new catheter table to be aware of self. Idealy, we should
         be using dictionaries, but it's too late at this point.
         Also, this function assumes that the catheter.index attribute in self matches the the index
-        of the catheter in self.catheter_list, while this assumption is not required for the 
+        of the catheter in self.catheters_list, while this assumption is not required for the 
         new_catheter_table (I know, horrible design choices!)
 
         ### Inputs:
@@ -1454,7 +1464,7 @@ def load_delivered_cathetertable_from_dicom(pth_dicom: Path) -> list:
         catheter["index"] -= empty_catheter_counter
         final_catheter_table.append(catheter)
     return {
-        "catheter_list": final_catheter_table,
+        "catheters_list": final_catheter_table,
         "treatment_time": treatment_time,
         "step_size": float(
             final_catheter_table[0]["dwells"][1]["relativePos"] 
@@ -1510,11 +1520,11 @@ def load_from_dicom(
     ### Inputs:
     - pth_dicom: Path := the path to the dicom file containing the catheter table.
     - from_delivered_dwellpositions: bool := if true, the dwell positions inside the 
-    catheter_list will only be the ones with non-zero dwell times. If false, the
+    catheters_list will only be the ones with non-zero dwell times. If false, the
     dwell positions will be created from the digitization points.
     ### Outputs:
     cat_dict := a dictionary containing the following keys:
-        - catheter_list
+        - catheters_list
         - step_size
     """
     
@@ -1524,7 +1534,7 @@ def load_from_dicom(
         catheter_table_dict, _ = dicom_to_catheter_table(dir_dicom=pth_dicom.parent)
 
     # add catheter index to the dwells
-    for catheter in catheter_table_dict["catheter_list"]:
+    for catheter in catheter_table_dict["catheters_list"]:
         for dwell in catheter["dwells"]:
             dwell["catheter_index"] = catheter["index"]
     
@@ -1548,7 +1558,7 @@ def load_from_json(pth_json: Path) -> list:
             catheter_table_list = cat_table
             step_size = catheter_table_list[0].get("step_size", None)
         elif isinstance(cat_table, dict):
-            catheter_table_list = cat_table.get("catheter_list", None)
+            catheter_table_list = cat_table.get("catheters_list", None)
             step_size = cat_table.get("step_size", None)
             non_zero_dwell_positions = cat_table.get("non_zero_dwell_positions", None)
         else:
@@ -1559,7 +1569,7 @@ def load_from_json(pth_json: Path) -> list:
         for catheter_dict in catheter_table_list:
             raw_catheter_table.append(Catheter(**catheter_dict))
         return {
-            "catheter_list":raw_catheter_table,
+            "catheters_list":raw_catheter_table,
             "step_size":step_size,
             "non_zero_dwell_positions": non_zero_dwell_positions
             }

--- a/brachyutils/geometry/catheter_utils/catheter_table.py
+++ b/brachyutils/geometry/catheter_utils/catheter_table.py
@@ -1332,9 +1332,6 @@ def load_delivered_cathetertable_from_dicom(pth_dicom: Path) -> list:
             for i in range(len(catheter["dwells"])):
                 catheter["dwells"][i]["rotation"] = get_rotation_from_position(i, catheter["dwells"])
         catheter["index"] -= empty_catheter_counter
-        # add catheter index to the dwells
-        for dwell in catheter["dwells"]:
-            dwell["catheter_index"] = catheter["index"]
         final_catheter_table.append(catheter)
     return {
         "catheter_list": final_catheter_table,
@@ -1404,7 +1401,13 @@ def load_from_dicom(
     if from_delivered_dwellpositions:
         catheter_table_dict = load_delivered_cathetertable_from_dicom(pth_dicom=pth_dicom)
     else:
-        catheter_table_dict,  = dicom_to_catheter_table(dir_dicom=pth_dicom.parent)
+        catheter_table_dict, _ = dicom_to_catheter_table(dir_dicom=pth_dicom.parent)
+
+    # add catheter index to the dwells
+    for catheter in catheter_table_dict["catheter_list"]:
+        for dwell in catheter["dwells"]:
+            dwell["catheter_index"] = catheter["index"]
+    
     return catheter_table_dict
 
 def load_from_json(pth_json: Path) -> list:

--- a/brachyutils/geometry/catheter_utils/catheter_table.py
+++ b/brachyutils/geometry/catheter_utils/catheter_table.py
@@ -802,18 +802,18 @@ class CatheterTable(BaseModel):
     def __sub__(self, other: "CatheterTable") -> "CatheterTable":
         r"""
         ### Purpose:
-        - To subtract the dwell times, position and rotation of one catheter table from the current catheter table.
-
+        - To subtract the dwell times, position and 
+        rotation of one catheter table from the current catheter table.
         ### Inputs:
         - self := the current CatheterTable object.
         - other := the CatheterTable object to be subtracted.
-
         ### Outputs:
-        - CatheterTable := the updated CatheterTable object.
+        - CatheterTable := A catheter table with the differences.
         """
         if not isinstance(other, CatheterTable):
             raise ValueError("other should be a CatheterTable object.")
-        # new_cat_table = copy.deepcopy(self)
+        list_catheter_diffs = []
+        list_dwell_diffs = []
         #if len(new_cat_table) != len(other):
         #    raise ValueError("The two catheter tables should have the same number of catheters to be subtracted.")
         for catheter in self.catheter_list:
@@ -824,11 +824,40 @@ class CatheterTable(BaseModel):
                     for dwell in catheter.dwells:
                         for other_dwell in other_catheter.dwells:
                             if dwell.index == other_dwell.index:
-                                dwell.time = dwell.time - other_dwell.time
+                                diff_time = dwell.time - other_dwell.time
+                                diff_angle = dwell.angle - other_dwell.angle
+                                diff_relativePos = dwell.relativePos - dwell.relativePos
+                                diff_position = np.zeros(3)
+                                diff_rotation = np.zeros(3)
                                 for i in range(3):
-                                    dwell.position[i] = dwell.position[i] - other_dwell.position[i]
-                                    dwell.rotation[i] = dwell.rotation[i] - other_dwell.rotation[i]
-        return self
+                                    diff_position[i] = dwell.position[i] - other_dwell.position[i]
+                                    diff_rotation[i] = dwell.rotation[i] - other_dwell.rotation[i]
+                                # gen dose rate if any attribute other than the dwell time has changed.
+                                diff_gen_doserate = False
+                                if (np.any(diff_position !=0) or np.any(diff_rotation !=0)
+                                    or diff_angle != 0 or diff_relativePos != 0):
+                                    diff_gen_doserate = True
+                                dwell_diff = DwellPosition(
+                                    index=dwell.index,
+                                    angle=diff_angle,
+                                    position=diff_position,
+                                    relativePos=diff_relativePos,
+                                    rotation=diff_rotation,
+                                    time=diff_time,
+                                    gen_dose_rate=diff_gen_doserate,
+                                    catheter_index=catheter.index
+                                )
+                                list_dwell_diffs.append(dwell_diff)
+                                
+                    list_catheter_diffs.append(
+                        Catheter(
+                            index=catheter.index,
+                            dwells=list_dwell_diffs,
+                        ))
+        return CatheterTable(
+            catheter_list=list_catheter_diffs,
+            from_delivered_dwellpositions=self.from_delivered_dwellpositions
+        )
 
     def append(self, catheter: Catheter) -> None:
         r"""
@@ -1196,6 +1225,44 @@ agree with the sum of dwells times that have dose rates ({sanity_time})")
                         file_name=f"run_{dwell_name}",
                         dose_extension=export_config_dose.file_extension)
         print(f"Dose exported to {dir_export}")
+
+    def update(self, new_catheter_table:"CatheterTable"):
+        r"""
+        ### Purpose:
+        - Given a new catheter table, update self.
+        dose rates are kept only if dwell time is updated. otherwise the 
+        dwells inside a catheter are replaced/deleted.
+        ### Inputs:
+        - new_catheter_table:CatheterTable := The new catheter table used
+        to update self.
+        ### Output:
+        None := update self.
+        """
+        catheter_table_diff = self - new_catheter_table 
+        time_diffs = {}
+        for catheter_diff in catheter_table_diff:
+            # if the catheter is not in the current catheter table, add the entire catheter with all its dwells.
+            if self[catheter_diff.index] is None:
+                self.append(new_catheter_table[catheter_diff.index])
+                continue
+            for dwell_diff in catheter_diff.dwells:
+                # if that dwell is not in the current cathetr, add it.
+                if self[catheter_diff.index][dwell_diff.index] is None:
+                    self[catheter_diff.index][dwell_diff.index] = new_catheter_table[catheter_diff.index][dwell_diff.index]
+                    continue
+                else:
+                    if np.any(dwell_diff.position != 0) or np.any(dwell_diff.rotation != 0):
+                        # if the postion or rotation of the dwell has changed,
+                        # update it in the catheter table and set gen_dose_rates to True for that catheter.
+                        self[catheter_diff.index][dwell_diff.index].position = new_catheter_table[catheter_diff.index][dwell_diff.index].position
+                        self[catheter_diff.index][dwell_diff.index].rotation = new_catheter_table[catheter_diff.index][dwell_diff.index].rotation
+                        self[catheter_diff.index].gen_dose_rates = True
+                    elif dwell_diff.time != 0:
+                        time_diffs[
+                            dwell_diff.name_id
+                            ] = dwell_diff.time
+                    else:
+                        continue
 
 def load_delivered_cathetertable_from_dicom(pth_dicom: Path) -> list:
     r"""

--- a/brachyutils/geometry/catheter_utils/catheter_table.py
+++ b/brachyutils/geometry/catheter_utils/catheter_table.py
@@ -1227,7 +1227,7 @@ agree with the sum of dwells times that have dose rates ({sanity_time})")
         print(f"Dose exported to {dir_export}")
 
     def update(self, new_catheter_table:"CatheterTable"):
-        r"""
+        r""" XXX: debug this with the finalized catheter update logic!
         ### Purpose:
         - Given a new catheter table, update self.
         dose rates are kept only if dwell time is updated. otherwise the 

--- a/brachyutils/geometry/catheter_utils/catheter_table.py
+++ b/brachyutils/geometry/catheter_utils/catheter_table.py
@@ -848,6 +848,23 @@ class CatheterTable(BaseModel):
         catheter.index = new_index
         self.catheter_list.append(catheter)
 
+    def get_dwell_by_name_ids(self, name_ids: List[str]) -> List[DwellPosition]:
+        r"""
+        ### Purpose:
+        - To return dwell positions that have the queried name ids.
+        The name ids are in the format {catheter.index+1}_{dwell_index+1}_{angle}
+        ### Inputs:
+        - name_ids := The list of name ids to be returned.
+        ### Outputs:
+        - out_dwells : List[DwellPosition] := The dwell positions with the matching name ids
+        """
+        out_dwells = []
+        for name_id in name_ids:
+            for dwell in self.all_dwells:
+                if dwell.name_id == name_id:
+                    out_dwells.append(dwell)
+        return out_dwells
+
     def reset_index(self) -> None:
         r"""
         ### Purpose:

--- a/brachyutils/geometry/catheter_utils/catheter_table.py
+++ b/brachyutils/geometry/catheter_utils/catheter_table.py
@@ -17,6 +17,9 @@ from brachyutils.geometry.catheter_utils.patch_ai_assisted_brachy.catheter_api i
     dicom_to_catheter_table, _update_catheter_table, CreatedSetUp
 )
 from brachyutils.dose.dose_utils import BrachyDose
+from concurrent.futures import ThreadPoolExecutor, as_completed
+from tqdm import tqdm
+from collections import defaultdict
 
 class DwellPosition(BaseModel):
     r"""
@@ -980,6 +983,100 @@ class CatheterTable(BaseModel):
         for catheter in self.catheter_list:
             catheter.remove_outside_mask(mask)
 
+    def load_dose_rates(
+        self,
+        dir_dose_rate: str| Path,
+        load_uncertainty:bool=False,
+        multi_processing: bool = True,
+        combined_dose_only: bool = False,
+        ):
+        r"""
+        ### Purpose:
+        - To load the dose rates into the CatheterTable object given a folder with
+        patient's dose rate files and the catheter table loaded into the BrachyPlan object.
+        In addition, combined dose is calculated as a linear combination of the dose rates
+        and dwell times.
+        ### Inputs:
+        - `dir_dose_rate` :=  path to the directory containing the dose rate files. we assume
+        that the name of the dose rate files end as "run_X_X_X.seq.nrrd".
+        where the X corresponds to the catheter index+1, dwell index+1, and angle in increasing order.
+        - `load_uncertainty`:= If true, uncertainty is loaded from the dose file, else it'll be set to 1. 
+        - `multi_processing` := if True, the dose rate files will be loaded in parallel. By default,
+        we use 8 cores for parallel processing.
+        - `combined_dose_only`:bool = False := flag to keep only the combined dose in memory after loading.
+        ### Outputs:
+        - Void := will update the BrachyPlan.dose_rate_dict attribute
+        """
+        if self.num_dwell_positions == 0:
+            raise ValueError("Cannot load dose rates since there is no catheters or dwells in this catheter table.")
+
+        pth_dose_rate = Path(dir_dose_rate).resolve()
+        if not pth_dose_rate.exists():
+            raise ValueError(f"directory of dose rates does not exist: {pth_dose_rate}")
+        dose_rate_files = list(pth_dose_rate.glob("run_*.seq.nrrd"))
+        new_dose_rate_files = []
+        # load file if they have not been loaded since modification
+        for pth in dose_rate_files:
+            # check if pth is not needed in catheter table skip it:
+            cat_index_from_pth, dwell_index_from_pth = pth.name.split("_")[1:3]
+            cat_index_from_pth, dwell_index_from_pth = int(cat_index_from_pth)-1, int(dwell_index_from_pth)-1
+            if 0 <= cat_index_from_pth < len(self):
+                dwells = catheter_table[cat_index_from_pth].dwells
+                if 0 <= dwell_index_from_pth < len(dwells):
+                    pass
+                else:
+                    continue
+            else:
+                continue
+
+            if not self.dose_rate_dict.get(pth.name, None):
+                new_dose_rate_files.append(pth)
+            elif pth.stat().st_mtime != self.dose_rate_dict.get(pth.name).modification_time:
+                new_dose_rate_files.append(pth)
+            else:
+                continue
+
+        if multi_processing:
+            with ThreadPoolExecutor(max_workers=16) as executor:
+                futures = {
+                    executor.submit(_load_single_dose_rate, pth, load_uncertainty): pth
+                    for pth in new_dose_rate_files
+                    }
+                for action in tqdm(
+                    as_completed(futures),
+                    desc="Loading dose rate maps",
+                    total=len(new_dose_rate_files)):
+                    try:
+                        dose_rate = action.result()
+                        self.dose_rate_dict[dose_rate.path.name] = dose_rate
+                    except:
+                        failed_path = futures[action]
+                        raise ValueError(f"Failed loading f{failed_path}")
+        else:
+            for pth in tqdm(
+                new_dose_rate_files,
+                desc="Loading dose rate maps",
+                total=len(new_dose_rate_files)):
+                dose_rate = _load_single_dose_rate(
+                    pth_dose_rate=pth,
+                    load_uncertainty=load_uncertainty)
+                dwell_id = dose_rate.path.name.split(".")[0].split("run_")[1]
+                self.dose_rate_dict[dwell_id] = dose_rate
+
+        # now sort dose rates according to increasing catheter name and shield numbers
+        # Fastest and most compact version
+        sorted_items = sorted(
+            self.dose_rate_dict.items(),
+            key=lambda f: tuple(map(int, f[0].removeprefix('run_').removesuffix('.seq.nrrd').split('_')))
+        )
+        self.dose_rate_dict = defaultdict(BrachyDose, sorted_items)
+
+        self._calculate_combined_dose()
+        if load_uncertainty:
+            self._calculate_combined_uncertainty()
+        if combined_dose_only:
+            del self.dose_rate_dict
+
 def load_delivered_cathetertable_from_dicom(pth_dicom: Path) -> list:
     r"""
     Purpose:
@@ -1066,6 +1163,51 @@ def load_delivered_cathetertable_from_dicom(pth_dicom: Path) -> list:
             }
         )
 
+    def export_dose(
+        self,
+        export_config_dose: ExportConfig_Dose
+    ):
+        r"""
+        ### Purpose:
+        - to export combined dose map and if needed the dose rate maps to a given directory.
+        exporting dose rate maps is optional.
+        ### Inputs:
+        - export_config_dose: The dose export configuration. Look at ExportConfig_Dose for more info 
+        ### Outputs:
+        - None := will export the dose map into the specified export directory.
+        ### Dependencies:
+        - _write_single_dose_rate()
+        - multiprocessing
+        """
+        assert self.combined_dose is not None, "combined dose is not calculated yet"
+        dir_export = Path(export_config_dose.dir_export)
+        # write combined dose
+        self.combined_dose.write_brachydose_to_file(
+            export_config_dose.pth_combined
+        )
+
+        if export_config_dose.write_dose_rate_maps:
+            if export_config_dose.multi_processing:
+                with ThreadPoolExecutor(max_workers=16) as executor:
+                    futures = {
+                        executor.submit(_write_single_dose_rate, self.dose_rate_dict.get(dose_rate_name), dir_export, export_config_dose.file_extension):
+                            dose_rate_name for dose_rate_name in self.dose_rate_dict
+                        }
+                    for action in tqdm(as_completed(futures), desc="Writing dose rate maps"):
+                        try:
+                            action.result()
+                        except:
+                            failed_path = futures[action]
+                            raise ValueError(f"Failed writing {failed_path}")
+            else:
+                for dose_rate in tqdm(self.dose_rate_dict, desc="Writing dose rate maps"):
+                    _write_single_dose_rate(
+                        dose_rate=self.dose_rate_dict.get(dose_rate),
+                        dir_export=dir_export,
+                        dose_extension=export_config_dose.file_extension)
+        print(f"Dose exported to {dir_export}")
+
+
     # # Convert control points to dwell positions:
     # # after extracting the final cummulative time weight of the catheters,
     # # the time of the catheter, and the cummulative time weight of the control points,
@@ -1138,3 +1280,35 @@ def load_delivered_cathetertable_from_dicom(pth_dicom: Path) -> list:
             - final_catheter_table[0]["dwells"][0]["relativePos"]
             )
     }
+    
+def _load_single_dose_rate(
+    pth_dose_rate:Path,
+    load_uncertainty=False
+    )->BrachyDose:
+        return BrachyDose(pth_dose_file=pth_dose_rate, load_uncertainty=load_uncertainty)
+
+def _write_single_dose_rate(
+    dose_rate:BrachyDose,
+    dir_export: str | Path = None,
+    dose_extension: str = None,
+    file_name: str = None,
+    ):
+    r"""
+    ### Purpose:
+    to write out a single dose rate map and uncertainty to a file.
+    ### Inputs:
+    - dose_rate:= The BrachyDose object for the dose rate data.
+    - dir_export:= the directory to which the dose rate maps will be exported
+    - file_name:= The name of the file inside dir_export. Following the RapidBrachy standard, it should be
+    "run_{catheter.index+1}_{dwell.index+1}_{angle}.seq.nrrd". if none, dose_rate.path.name is used.
+    - dose_extension := the type of dose rate map to be exported. options are ".3ddose", ".minidos", or ".nrrd"
+    ### Output:
+    - Void := dose file is written to dir_export+f"/{file_name}.{dose_type}
+    """
+    if file_name is None:
+        file_name = dose_rate.path.name.split(".")[0]
+    if dose_extension is None:
+        dose_extension = ".seq.nrrd"
+    dir_export = Path(dir_export)
+    pth_out = dir_export/(file_name+dose_extension)
+    dose_rate.write_brachydose_to_file(pth_dose_file=pth_out)

--- a/brachyutils/planning/optimization/optim_cath/dosimetric_gurobi.py
+++ b/brachyutils/planning/optimization/optim_cath/dosimetric_gurobi.py
@@ -300,7 +300,7 @@ def set_catheter_variables(
         name_cath_to_keep=[]
     for catheter in tqdm(
         plan.catheter_table,
-        total=len(plan.catheter_table.catheter_list),
+        total=len(plan.catheter_table.catheters_list),
         desc="Creating optimization variables from new catheters"):
         if f"catheter_{catheter.index+1}" in name_cath_to_keep:
             continue

--- a/brachyutils/planning/plan_utils.py
+++ b/brachyutils/planning/plan_utils.py
@@ -565,7 +565,7 @@ class BrachyPlan:
 
             # extract the attributes above from the catheter table
             dwell_counter = 1
-            for catheter in self.catheter_table.catheter_list:
+            for catheter in self.catheter_table.catheters_list:
                 self.catheter_numbers = np.append(self.catheter_numbers, catheter.index)
                 for dwell in catheter.dwells:
                     self.dwell_numbers = np.append(self.dwell_numbers, dwell_counter)

--- a/brachyutils/planning/plan_utils.py
+++ b/brachyutils/planning/plan_utils.py
@@ -576,11 +576,6 @@ class BrachyPlan:
                         mask=mask,
                         margin_mm=5.0,
                     )
-        #if 'time_diffs' in locals():
-        #    print("########################")
-        #    print(f"time diffs {time_diffs.items()}")
-        #    print("########################")
-
         self.update_plan_from_catheter_table(
             time_diffs=time_diffs if 'time_diffs' in locals() else None)
 
@@ -746,7 +741,12 @@ class BrachyPlan:
         The result is stored in the combined_dose attribute.
         We require strict name matching between the dwell names and dose rate names!
         ### Inputs:
-        - time_diffs: a dictionary of time differences for each dwell in the plan. This is used to update the combined dose if the dwell times are updated without having to reload the dose rate maps. The keys of the dictionary should be in the format "catheter_{catheter_index}_dwell_{dwell_index}" and the values should be the time differences in seconds. If None, the combined dose will be calculated using the current dwell times in the plan.
+        - time_diffs: a dictionary of time differences for each dwell in the plan. 
+        This is used to update the combined dose if the dwell times are updated without
+        having to reload the dose rate maps. The keys of the dictionary should be in
+        the format "catheter_{catheter_index}_dwell_{dwell_index}" and the values
+        should be the time differences in seconds. If None, the combined dose will
+        be calculated using the current dwell times in the plan.
         ### Outputs:
         - None: but it needs the following attributes to be filled:
         - self.dose_rate_dict

--- a/brachyutils/planning/plan_utils.py
+++ b/brachyutils/planning/plan_utils.py
@@ -503,7 +503,7 @@ class BrachyPlan:
         """
         if isinstance(catheter_table, (str, Path)):
             self.catheter_table = CatheterTable(
-                catheter_list=catheter_table,
+                catheters_dict=catheter_table,
                 from_delivered_dwellpositions=from_delivered_dwellpositions,
                 )
         elif isinstance(catheter_table, CatheterTable):

--- a/brachyutils/planning/plan_utils.py
+++ b/brachyutils/planning/plan_utils.py
@@ -572,6 +572,8 @@ class BrachyPlan:
                             gridSize=self.phantom.image_obj.gridSize,
                             spacing=self.phantom.image_obj.spacing,
                         )
+                    else:
+                        mask = structure.mask
                     self.catheter_table.remove_outside_mask(
                         mask=mask,
                         margin_mm=5.0,

--- a/brachyutils/planning/plan_utils.py
+++ b/brachyutils/planning/plan_utils.py
@@ -217,8 +217,6 @@ class BrachyPlan:
         #### for loading dose or uncertainty:
         combined_dose: Union[Path, str, BrachyDose] = None,
         dir_dose_rate: Path = None,
-        multi_processing: bool = False,
-        combined_dose_only: bool = False,
         #### for simulation setup:
         simulation_setup: dict | Path | str = None,
         #### for optimization setup:
@@ -246,8 +244,6 @@ class BrachyPlan:
         #### for loading dose rates or uncertainty maps per dwell position:
         - combined_dose: Path|BrachyDose := the path to the combined dose file or a BrachyDose object.
         - dir_dose_rate:str := path to the directory containing the dose rate files for a patient.
-        - multi_processing:bool = False := flag to enable multi-processing for loading dose or uncertainty (default is False).
-        - combined_dose_only:bool = False := flag to keep only the combined dose in memory after loading (default is False).
 
         #### Keywords Arguments:
         - from_delivered_dwellpositions: bool = True := if True, will only load the dwell positions that
@@ -263,7 +259,11 @@ class BrachyPlan:
         - load_uncertainty: bool := If true, it will the uncertainty of the dose rates as well. 
         #### for simulation setup:
         - simulation_setup = None := dictionary containing the simulation setup,
-
+        - load_uncertainty:bool := If True, the uncertainties of the dose rates are also loaded. 
+        - multi_processing:bool :=  If True, 16 threads are used to load the dose rates simulatenously.
+        - combined_dose_only:bool := If True, all the dose rates will be removed from memory after 
+        combined dose is calculated.
+        - dose_dtype:np.float32 := The floating point type to store the dose rates. 
         ### Outputs:
             - Void := will initialize the BrachyPlan object
         """
@@ -339,12 +339,15 @@ class BrachyPlan:
                 )
         # load the dose rate dict if the path is provided
         if dir_dose_rate is not None and combined_dose is None:
-            self.load_dose_rates(
+            self.catheter_table.load_dose_rates(
                 dir_dose_rate=dir_dose_rate,
                 load_uncertainty=kwargs.get("load_uncertainty", False),
-                multi_processing=multi_processing,
-                combined_dose_only=combined_dose_only,
-            )
+                multi_processing=kwargs.get("multi_processing", True),
+                combined_dose_only=kwargs.get("combined_dose_only", False),
+                dose_dtype=kwargs.get("dose_dtype", np.float32),
+                )
+            self.combined_dose = self.catheter_table.combined_dose
+
         elif dir_dose_rate is None and combined_dose is not None:
             if isinstance(combined_dose, BrachyDose):
                 self.combined_dose = combined_dose

--- a/brachyutils/planning/plan_utils.py
+++ b/brachyutils/planning/plan_utils.py
@@ -883,31 +883,6 @@ class BrachyPlan:
         else:
             raise ValueError("format should be either 'RapidBrachy' or 'WebApp'")
 
-    def _calculate_combined_uncertainty(self):
-        r"""
-        ### Purpose:
-        - To calculate the combined uncertainty of the combined dose map based on the
-        dose rate dictionary and dwell times.
-        We require strict name matching between the dwell names and the name of dose rate files
-        ### Inputs:
-        - self := the BrachyPlan object
-        ### Outputs:
-        - Void := will update the BrachyPlan.combined_dose.uncertainty attribute
-        """
-        assert self.combined_dose is not None, "combined dose is not calculated yet"
-        if not any(self.dose_rate_dict):
-            raise ValueError("dose rate tensor is empty. Run load_dose_rates()")
-
-        treatment_time = self.catheter_table.treatment_time
-        for catheter in self.catheter_table:
-            for dwell in catheter.dwells:
-                self.combined_dose.uncertainty_image.imageArray += (self.dose_rate_dict.get(
-                    # f"run_{catheter.index+1}_{dwell.index+1}_{int(dwell.angle)}.seq.nrrd"
-                    dwell.name_id
-                    ).uncertainty_image.imageArray * (dwell.time/treatment_time)**2)
-        self.combined_dose.uncertainty_image.imageArray = np.sqrt(
-            self.combined_dose.uncertainty_image.imageArray)
-
     def get_dvh_metrics(
         self,
         combined_dose: BrachyDose=None,

--- a/brachyutils/planning/plan_utils.py
+++ b/brachyutils/planning/plan_utils.py
@@ -636,103 +636,6 @@ class BrachyPlan:
         if any(self.dose_rate_dict):
             self._calculate_combined_dose(time_diffs=time_diffs)
 
-    def load_dose_rate_dict(
-        self,
-        dir_dose_rate: str| Path,
-        load_uncertainty:bool=False,
-        multi_processing: bool = True,
-        combined_dose_only: bool = False,
-        catheter_table: CatheterTable = None,
-    ):
-        r"""
-        ### Purpose:
-        - To load the dose rates into the BrachyPlan object given a folder with
-        patient's dose rate files and the catheter table loaded into the BrachyPlan object.
-        In addition, combined dose is calculated as a linear combination of the dose rates
-        and dwell times.
-        ### Inputs:
-        - `dir_dose_rate` :=  path to the directory containing the dose rate files. we assume
-        that the name of the dose rate files end as "run_X_X_X.seq.nrrd".
-        where the X corresponds to the catheter index+1, dwell index+1, and angle in increasing order.
-        - `load_uncertainty`:= If true, uncertainty is loaded from the dose file, else it'll be set to 1. 
-        - `multi_processing` := if True, the dose rate files will be loaded in parallel. By default,
-        we use 8 cores for parallel processing.
-        - `combined_dose_only`:bool = False := flag to keep only the combined dose in memory after loading.
-        ### Outputs:
-        - Void := will update the BrachyPlan.dose_rate_dict attribute
-        """
-        # make sure catheter table is loaded
-        if catheter_table is None:
-            assert self.catheter_table is not None, "catheter table is not loaded"
-            catheter_table = self.catheter_table
-
-        pth_dose_rate = Path(dir_dose_rate).resolve()
-        if not pth_dose_rate.exists():
-            raise ValueError(f"directory of dose rates does not exist: {pth_dose_rate}")
-        dose_rate_files = list(pth_dose_rate.glob("run_*.seq.nrrd"))
-        new_dose_rate_files = []
-        # load file if they have not been loaded since modification
-        for pth in dose_rate_files:
-            # check if pth is not needed in catheter table skip it:
-            cat_index_from_pth, dwell_index_from_pth = pth.name.split("_")[1:3]
-            cat_index_from_pth, dwell_index_from_pth = int(cat_index_from_pth)-1, int(dwell_index_from_pth)-1
-            if 0 <= cat_index_from_pth < len(catheter_table):
-                dwells = catheter_table[cat_index_from_pth].dwells
-                if 0 <= dwell_index_from_pth < len(dwells):
-                    pass
-                else:
-                    continue
-            else:
-                continue
-
-            if not self.dose_rate_dict.get(pth.name, None):
-                new_dose_rate_files.append(pth)
-            elif pth.stat().st_mtime != self.dose_rate_dict.get(pth.name).modification_time:
-                new_dose_rate_files.append(pth)
-            else:
-                continue
-
-        if multi_processing:
-            with ThreadPoolExecutor(max_workers=16) as executor:
-                futures = {
-                    executor.submit(_load_single_dose_rate, pth, load_uncertainty): pth
-                    for pth in new_dose_rate_files
-                    }
-                for action in tqdm(
-                    as_completed(futures),
-                    desc="Loading dose rate maps",
-                    total=len(new_dose_rate_files)):
-                    try:
-                        dose_rate = action.result()
-                        self.dose_rate_dict[dose_rate.path.name] = dose_rate
-                    except:
-                        failed_path = futures[action]
-                        raise ValueError(f"Failed loading f{failed_path}")
-        else:
-            for pth in tqdm(
-                new_dose_rate_files,
-                desc="Loading dose rate maps",
-                total=len(new_dose_rate_files)):
-                dose_rate = _load_single_dose_rate(
-                    pth_dose_rate=pth,
-                    load_uncertainty=load_uncertainty)
-                dwell_id = dose_rate.path.name.split(".")[0].split("run_")[1]
-                self.dose_rate_dict[dwell_id] = dose_rate
-
-        # now sort dose rates according to increasing catheter name and shield numbers
-        # Fastest and most compact version
-        sorted_items = sorted(
-            self.dose_rate_dict.items(),
-            key=lambda f: tuple(map(int, f[0].removeprefix('run_').removesuffix('.seq.nrrd').split('_')))
-        )
-        self.dose_rate_dict = defaultdict(BrachyDose, sorted_items)
-
-        self._calculate_combined_dose()
-        if load_uncertainty:
-            self._calculate_combined_uncertainty()
-        if combined_dose_only:
-            del self.dose_rate_dict
-
     def _calculate_combined_dose(self, time_diffs=None):
         """
         ### Purpose:
@@ -754,7 +657,7 @@ class BrachyPlan:
             AssertionError: If the dose rate tensor or dwell times array is empty.
         """
         if not any(self.dose_rate_dict):
-            raise ValueError("dose rate tensor is empty. Run load_dose_rate_dict()")
+            raise ValueError("dose rate tensor is empty. Run load_dose_rates()")
         if self.combined_dose is None:
             self.combined_dose = BrachyDose.dose_with_empty_grid_like(
                 list(self.dose_rate_dict.values())[0])        
@@ -1046,7 +949,7 @@ class BrachyPlan:
         """
         assert self.combined_dose is not None, "combined dose is not calculated yet"
         if not any(self.dose_rate_dict):
-            raise ValueError("dose rate tensor is empty. Run load_dose_rate_dict()")
+            raise ValueError("dose rate tensor is empty. Run load_dose_rates()")
 
         treatment_time = self.catheter_table.treatment_time
         for catheter in self.catheter_table:
@@ -1268,50 +1171,6 @@ class BrachyPlan:
             catheter_table.write_json(
                 export_config_cathetertable.dir_export
             )
-
-    def export_dose(
-        self,
-        export_config_dose: ExportConfig_Dose
-    ):
-        r"""
-        ### Purpose:
-        - to export combined dose map and if needed the dose rate maps to a given directory.
-        exporting dose rate maps is optional.
-        ### Inputs:
-        - export_config_dose: The dose export configuration. Look at ExportConfig_Dose for more info 
-        ### Outputs:
-        - None := will export the dose map into the specified export directory.
-        ### Dependencies:
-        - _write_single_dose_rate()
-        - multiprocessing
-        """
-        assert self.combined_dose is not None, "combined dose is not calculated yet"
-        dir_export = Path(export_config_dose.dir_export)
-        # write combined dose
-        self.combined_dose.write_brachydose_to_file(
-            export_config_dose.pth_combined
-        )
-
-        if export_config_dose.write_dose_rate_maps:
-            if export_config_dose.multi_processing:
-                with ThreadPoolExecutor(max_workers=16) as executor:
-                    futures = {
-                        executor.submit(_write_single_dose_rate, self.dose_rate_dict.get(dose_rate_name), dir_export, export_config_dose.file_extension):
-                            dose_rate_name for dose_rate_name in self.dose_rate_dict
-                        }
-                    for action in tqdm(as_completed(futures), desc="Writing dose rate maps"):
-                        try:
-                            action.result()
-                        except:
-                            failed_path = futures[action]
-                            raise ValueError(f"Failed writing {failed_path}")
-            else:
-                for dose_rate in tqdm(self.dose_rate_dict, desc="Writing dose rate maps"):
-                    _write_single_dose_rate(
-                        dose_rate=self.dose_rate_dict.get(dose_rate),
-                        dir_export=dir_export,
-                        dose_extension=export_config_dose.file_extension)
-        print(f"Dose exported to {dir_export}")
 
     def export_plan_files(
         self,
@@ -1877,38 +1736,6 @@ def _gen_hotspot_mask(
         is_target=False,
         in_dvh=False,
     )
-
-def _write_single_dose_rate(
-    dose_rate:BrachyDose,
-    dir_export: str | Path = None,
-    dose_extension: str = None,
-    file_name: str = None,
-    ):
-    r"""
-    ### Purpose:
-    to write out a single dose rate map and uncertainty to a directory.
-    ### Inputs:
-    - dose_rate:= The BrachyDose object for the dose rate data.
-    - dir_export:= the directory to which the dose rate maps will be exported
-    - file_name:= The name of the file inside dir_export. Following the RapidBrachy standard, it should be
-    "run_{catheter.index+1}_{dwell.index+1}_{angle}.seq.nrrd". if none, dose_rate.path.name is used.
-    - dose_extension := the type of dose rate map to be exported. options are ".3ddose", ".minidos", or ".nrrd"
-    ### Output:
-    - Void := dose file is written to dir_export+f"/{file_name}.{dose_type}
-    """
-    if file_name is None:
-        file_name = dose_rate.path.name.split(".")[0]
-    if dose_extension is None:
-        dose_extension = ".seq.nrrd"
-    dir_export = Path(dir_export)
-    pth_out = dir_export/(file_name+dose_extension)
-    dose_rate.write_brachydose_to_file(pth_dose_file=pth_out)
-
-def _load_single_dose_rate(
-    pth_dose_rate:Path,
-    load_uncertainty=False
-    )->BrachyDose:
-        return BrachyDose(pth_dose_file=pth_dose_rate, load_uncertainty=load_uncertainty)
 
 def _type_nested_dict_list(data):
 

--- a/brachyutils/planning/plan_utils.py
+++ b/brachyutils/planning/plan_utils.py
@@ -509,31 +509,7 @@ class BrachyPlan:
             if self.catheter_table is None:
                 self.catheter_table = catheter_table
             else:
-                catheter_table_diff = catheter_table - self.catheter_table 
-                time_diffs = {}
-                for catheter_diff in catheter_table_diff:
-                    # if the catheter is not in the current catheter table, add the entire catheter with all its dwells.
-                    if self.catheter_table[catheter_diff.index] is None:
-                        self.catheter_table.append(catheter_table[catheter_diff.index])
-                        continue
-                    for dwell_diff in catheter_diff.dwells:
-                        # if that dwell is not in the current cathetr, add it.
-                        if self.catheter_table[catheter_diff.index][dwell_diff.index] is None:
-                            self.catheter_table[catheter_diff.index][dwell_diff.index] = catheter_table[catheter_diff.index][dwell_diff.index]
-                            continue
-                        else:
-                            if np.any(dwell_diff.position != 0) or np.any(dwell_diff.rotation != 0):
-                                # if the postion or rotation of the dwell has changed,
-                                # update it in the catheter table and set gen_dose_rates to True for that catheter.
-                                self.catheter_table[catheter_diff.index][dwell_diff.index].position = catheter_table[catheter_diff.index][dwell_diff.index].position
-                                self.catheter_table[catheter_diff.index][dwell_diff.index].rotation = catheter_table[catheter_diff.index][dwell_diff.index].rotation
-                                self.catheter_table[catheter_diff.index].gen_dose_rates = True
-                            elif dwell_diff.time != 0:
-                                time_diffs[
-                                    dwell_diff.name_id
-                                    ] = dwell_diff.time
-                            else:
-                                continue
+                self.catheter_table.update(catheter_table)
         else:
             raise ValueError(
                 "catheter_table should be a path or a CatheterTable object"

--- a/brachyutils/planning/plan_utils.py
+++ b/brachyutils/planning/plan_utils.py
@@ -241,7 +241,6 @@ class BrachyPlan:
         #### for loading dose or uncertainty:
         combined_dose: Union[Path, str, BrachyDose] = None,
         dir_dose_rate: Path = None,
-        load_uncertainty:bool=False,
         multi_processing: bool = False,
         combined_dose_only: bool = False,
         #### for simulation setup:
@@ -285,7 +284,7 @@ class BrachyPlan:
         - one_hotspot_structure: bool: = True := if False, will create separate hotspot structures
         - applicator_format:str = "RapidBrachy" := the format of the applicator list 
         (default is "RapidBrachy"). See load_applicator_list() for more info. 
-
+        - load_uncertainty: bool := If true, it will the uncertainty of the dose rates as well. 
         #### for simulation setup:
         - simulation_setup = None := dictionary containing the simulation setup,
 
@@ -364,9 +363,9 @@ class BrachyPlan:
                 )
         # load the dose rate dict if the path is provided
         if dir_dose_rate is not None and combined_dose is None:
-            self.load_dose_rate_dict(
+            self.load_dose_rates(
                 dir_dose_rate=dir_dose_rate,
-                load_uncertainty=load_uncertainty,
+                load_uncertainty=kwargs.get("load_uncertainty", False),
                 multi_processing=multi_processing,
                 combined_dose_only=combined_dose_only,
             )
@@ -552,7 +551,7 @@ class BrachyPlan:
                                 self.catheter_table[catheter_diff.index].gen_dose_rates = True
                             elif dwell_diff.time != 0:
                                 time_diffs[
-                                    f"catheter_{catheter_diff.index+1}_dwell_{dwell_diff.index+1}"
+                                    dwell_diff.name_id
                                     ] = dwell_diff.time
                             else:
                                 continue
@@ -653,7 +652,7 @@ class BrachyPlan:
         and dwell times.
         ### Inputs:
         - `dir_dose_rate` :=  path to the directory containing the dose rate files. we assume
-        that the name of the dose rate files end as "run_X_X_X.seq.nrrd", "run_X_X_X.seq.nrrd", etc.
+        that the name of the dose rate files end as "run_X_X_X.seq.nrrd".
         where the X corresponds to the catheter index+1, dwell index+1, and angle in increasing order.
         - `load_uncertainty`:= If true, uncertainty is loaded from the dose file, else it'll be set to 1. 
         - `multi_processing` := if True, the dose rate files will be loaded in parallel. By default,
@@ -717,7 +716,8 @@ class BrachyPlan:
                 dose_rate = _load_single_dose_rate(
                     pth_dose_rate=pth,
                     load_uncertainty=load_uncertainty)
-                self.dose_rate_dict[dose_rate.path.name] = dose_rate
+                dwell_id = dose_rate.path.name.split(".")[0].split("run_")[1]
+                self.dose_rate_dict[dwell_id] = dose_rate
 
         # now sort dose rates according to increasing catheter name and shield numbers
         # Fastest and most compact version
@@ -763,7 +763,8 @@ class BrachyPlan:
             for catheter in self.catheter_table:
                 for dwell in catheter.dwells:
                         self.combined_dose.dose_image.imageArray += self.dose_rate_dict.get(
-                            f"run_{catheter.index+1}_{dwell.index+1}_{int(dwell.angle)}.seq.nrrd"
+                            # f"run_{catheter.index+1}_{dwell.index+1}_{int(dwell.angle)}.seq.nrrd"
+                            dwell.name_id
                             ).dose_image.imageArray * dwell.time
         else:
             for dwell_key, time_diff in time_diffs.items():
@@ -782,7 +783,8 @@ class BrachyPlan:
                 dose_rate_key = f"run_{catheter_number}_{dwell_number}_0.seq.nrrd"
                 #print(f"dose_rate_key {dose_rate_key}")
                 #print(f"calculate_combined_dose() time_diff {time_diff}")
-                self.combined_dose.dose_image.imageArray += (self.dose_rate_dict.get(dose_rate_key).dose_image.imageArray * time_diff)
+                self.combined_dose.dose_image.imageArray += (
+                    self.dose_rate_dict.get(dose_rate_key).dose_image.imageArray * time_diff)
 
     def set_dvh_metric_goals(self, dvh_metric_goals: Union[dict, Path]):
         r"""
@@ -1050,7 +1052,8 @@ class BrachyPlan:
         for catheter in self.catheter_table:
             for dwell in catheter.dwells:
                 self.combined_dose.uncertainty_image.imageArray += (self.dose_rate_dict.get(
-                    f"run_{catheter.index+1}_{dwell.index+1}_{int(dwell.angle)}.seq.nrrd"
+                    # f"run_{catheter.index+1}_{dwell.index+1}_{int(dwell.angle)}.seq.nrrd"
+                    dwell.name_id
                     ).uncertainty_image.imageArray * (dwell.time/treatment_time)**2)
         self.combined_dose.uncertainty_image.imageArray = np.sqrt(
             self.combined_dose.uncertainty_image.imageArray)
@@ -1832,10 +1835,9 @@ config do not match for structure {struc.name}"
         dose_rates_catheter = defaultdict(BrachyDose)
         
         for name, dose_rate in self.dose_rate_dict.items():
-            cath_num = name.split("_")[1]
-            if catheter_index+1 == int(cath_num):
-                dwell_num = name.split("_")[2]
-                dose_rates_catheter[f"catheter_{cath_num}_dwell_{dwell_num}"] = dose_rate
+            curr_indx = int(name.split("_")[0])-1
+            if curr_indx == catheter_index:
+                dose_rates_catheter[name] = dose_rate
         return dose_rates_catheter
 
 def _gen_hotspot_mask(

--- a/brachyutils/planning/plan_utils.py
+++ b/brachyutils/planning/plan_utils.py
@@ -1810,60 +1810,6 @@ config do not match for structure {struc.name}"
                 continue
             structure.optimization_config = None
 
-    def run_dose_generation(
-        self,
-        dir_export: str | Path = None,
-        dose_generator_obj: BrachyDoseGenerator = None,
-        generate_dose_rate_maps: bool = False,
-        export_config_brachyplan: ExportConfig_BrachyPlan = None,
-        ):
-        r"""
-        ### Purpose:
-        - to run the dose generation for the plan and update the combined dose.
-        ### Inputs:
-        - dose_generator_obj := the BrachyDoseGenerator object to be used for dose generation
-        - generate_dose_rate_maps := whether to generate dose rate maps for each dwell position.
-        If True, the dose_rate_dict will be populated with the dose rate maps for each dwell position.
-        - dir_export := the directory used for exporting the dosimetry setup and the generated dose maps.
-        if None, "temp_data/tg43/"
-        """
-        plan_name = self.phantom.pth_image.stem
-        if "." in plan_name:
-            plan_name = plan_name.split(".")[0]
-
-        if dir_export is None:
-            # XXX check the full path with resolve to be correct.
-            dir_export = Path("temp_data/tg43/")/plan_name
-
-        dir_export = Path(dir_export)
-        if dose_generator_obj is None:
-            dose_generator_obj = DoseTG43(dir_plan_export=dir_export)
-
-        if not isinstance(dose_generator_obj, BrachyDoseGenerator):
-            raise ValueError("dose_generator_obj should be an instance of BrachyDoseGenerator")
-        # export the plan for dosimetry
-        if export_config_brachyplan is None:
-            export_config_brachyplan = ExportConfig_BrachyPlan(
-                dir_export=dir_export,
-                export_config_egsphant=True,
-                export_config_planfile=True,
-                export_config_macfile=True,
-            )
-        self.export_brachy_plan(export_config_brachyplan)
-        # call the dose generator to generate the dose maps
-        dose_generator_obj.generate_dose(
-            output_dose_per_dwell= "dose_rate" if generate_dose_rate_maps else False,
-        )
-        # load the generated dose maps and update the plan
-        if generate_dose_rate_maps:
-            self.load_dose_rate_dict(
-                dir_dose_rate=dir_export,
-            )
-        else:
-            self.combined_dose = BrachyDose(
-                export_config_brachyplan.export_config_macfile.pth_combined.with_suffix(".seq.nrrd")
-                )            
-
     def get_dose_rate_matrices_for_catheter(
         self,
         catheter_index: int

--- a/brachyutils/planning/plan_utils.py
+++ b/brachyutils/planning/plan_utils.py
@@ -25,7 +25,6 @@ from brachyutils.geometry.catheter_utils.catheter_table import CatheterTable
 from brachyutils.planning.structure_utils import BrachyStructure
 from brachyutils.planning.simulation_utils import BrachySimulation
 from brachyutils.planning.optimization.optim_utils import Optimization_Config
-from brachyutils.dose.dose_generation_utils import BrachyDoseGenerator, DoseTG43
 from pydantic import BaseModel, ConfigDict, Field, model_validator, computed_field
 
 class ExportConfig_Dose(BaseModel):

--- a/brachyutils/planning/plan_utils.py
+++ b/brachyutils/planning/plan_utils.py
@@ -1812,9 +1812,9 @@ config do not match for structure {struc.name}"
 
     def run_dose_generation(
         self,
-        dose_generator_obj: BrachyDoseGenerator = None,
-        generate_dose_rate_maps: bool = True,
         dir_export: str | Path = None,
+        dose_generator_obj: BrachyDoseGenerator = None,
+        generate_dose_rate_maps: bool = False,
         export_config_brachyplan: ExportConfig_BrachyPlan = None,
         ):
         r"""
@@ -1851,7 +1851,7 @@ config do not match for structure {struc.name}"
             )
         self.export_brachy_plan(export_config_brachyplan)
         # call the dose generator to generate the dose maps
-        dose_generator_obj.run_dose_generation(
+        dose_generator_obj.generate_dose(
             output_dose_per_dwell= "dose_rate" if generate_dose_rate_maps else False,
         )
         # load the generated dose maps and update the plan

--- a/brachyutils/planning/plan_utils.py
+++ b/brachyutils/planning/plan_utils.py
@@ -21,12 +21,11 @@ from brachyutils.dose.dose_utils import BrachyDose
 # from brachyutils.egsphant_utils import BrachyEgsphant
 from brachyutils.geometry.applicator_utils import BrachyApplicator 
 from brachyutils.geometry.phantom_utils import BrachyPhantom
-from brachyutils.geometry.catheter_utils.catheter_table import Catheter, CatheterTable
+from brachyutils.geometry.catheter_utils.catheter_table import CatheterTable
 from brachyutils.planning.structure_utils import BrachyStructure
 from brachyutils.planning.simulation_utils import BrachySimulation
-# from brachyutils.types import Optimization_Config
 from brachyutils.planning.optimization.optim_utils import Optimization_Config
-
+from brachyutils.dose.dose_generation_utils import BrachyDoseGenerator, DoseTG43
 from pydantic import BaseModel, ConfigDict, Field, model_validator, computed_field
 
 class ExportConfig_Dose(BaseModel):
@@ -297,7 +296,6 @@ class BrachyPlan:
         # declare the attributes
         # patient origin is used as a reference point for the catheter table,
         # the dwell coordinates, image origin, egsphant, and the dose objects.
-        # XXX: figure out how to sort out patient origin to match all above.
 
         # phantom and geometry attributes
         self.phantom: BrachyPhantom = None
@@ -1118,7 +1116,6 @@ class BrachyPlan:
         with open(output_pth, "w") as json_file:
             json.dump(self.dvh_metric_goals, json_file, indent=4)
 
-
     def calculate_uncertainty_per_structure(self):
         r"""
         ### Purpose:
@@ -1813,6 +1810,60 @@ config do not match for structure {struc.name}"
                 continue
             structure.optimization_config = None
 
+    def run_dose_generation(
+        self,
+        dose_generator_obj: BrachyDoseGenerator = None,
+        generate_dose_rate_maps: bool = True,
+        dir_export: str | Path = None,
+        export_config_brachyplan: ExportConfig_BrachyPlan = None,
+        ):
+        r"""
+        ### Purpose:
+        - to run the dose generation for the plan and update the combined dose.
+        ### Inputs:
+        - dose_generator_obj := the BrachyDoseGenerator object to be used for dose generation
+        - generate_dose_rate_maps := whether to generate dose rate maps for each dwell position.
+        If True, the dose_rate_dict will be populated with the dose rate maps for each dwell position.
+        - dir_export := the directory used for exporting the dosimetry setup and the generated dose maps.
+        if None, "temp_data/tg43/"
+        """
+        plan_name = self.phantom.pth_image.stem
+        if "." in plan_name:
+            plan_name = plan_name.split(".")[0]
+
+        if dir_export is None:
+            # XXX check the full path with resolve to be correct.
+            dir_export = Path("temp_data/tg43/")/plan_name
+
+        dir_export = Path(dir_export)
+        if dose_generator_obj is None:
+            dose_generator_obj = DoseTG43(dir_plan_export=dir_export)
+
+        if not isinstance(dose_generator_obj, BrachyDoseGenerator):
+            raise ValueError("dose_generator_obj should be an instance of BrachyDoseGenerator")
+        # export the plan for dosimetry
+        if export_config_brachyplan is None:
+            export_config_brachyplan = ExportConfig_BrachyPlan(
+                dir_export=dir_export,
+                export_config_egsphant=True,
+                export_config_planfile=True,
+                export_config_macfile=True,
+            )
+        self.export_brachy_plan(export_config_brachyplan)
+        # call the dose generator to generate the dose maps
+        dose_generator_obj.run_dose_generation(
+            output_dose_per_dwell= "dose_rate" if generate_dose_rate_maps else False,
+        )
+        # load the generated dose maps and update the plan
+        if generate_dose_rate_maps:
+            self.load_dose_rate_dict(
+                dir_dose_rate=dir_export,
+            )
+        else:
+            self.combined_dose = BrachyDose(
+                export_config_brachyplan.export_config_macfile.pth_combined.with_suffix(".seq.nrrd")
+                )            
+
     def get_dose_rate_matrices_for_catheter(
         self,
         catheter_index: int
@@ -1829,6 +1880,8 @@ config do not match for structure {struc.name}"
         TODO: get rid of +1 when moving towards catheter generation from digi points
         TODO: Consider adding angle to the name later when IMBT is involved.
         """
+        if len(self.dose_rate_dict) == 0:
+            raise ValueError("dose rate maps are not generated yet. run dose generation first")
         dose_rates_catheter = defaultdict(BrachyDose)
         
         for name, dose_rate in self.dose_rate_dict.items():

--- a/brachyutils/planning/plan_utils.py
+++ b/brachyutils/planning/plan_utils.py
@@ -510,7 +510,7 @@ class BrachyPlan:
             if self.catheter_table is None:
                 self.catheter_table = catheter_table
             else:
-                self.catheter_table.update(catheter_table)
+                self.catheter_table.merge(catheter_table)
         else:
             raise ValueError(
                 "catheter_table should be a path or a CatheterTable object"

--- a/brachyutils/planning/plan_utils.py
+++ b/brachyutils/planning/plan_utils.py
@@ -298,7 +298,7 @@ class BrachyPlan:
 
         # dose attributes
         self.dose_rate_dict = defaultdict(BrachyDose)
-        self.combined_dose: BrachyDose = None
+        # self.combined_dose: BrachyDose = None
 
         # simulation attributes
         self.simulation_setup: BrachySimulation = None
@@ -397,6 +397,10 @@ class BrachyPlan:
                 add_hotspots_to_phantom=kwargs.get("add_hotspots_to_phantom", False),
                 one_hotspot_structure=kwargs.get("one_hotspot_structure", True),
             )
+
+    @computed_field
+    def combined_dose(self):
+        return self.catheter_table.combined_dose
 
     def load_phantom(self, pth_phantom: Union[Path, dict]):
         r"""

--- a/brachyutils/planning/plan_utils.py
+++ b/brachyutils/planning/plan_utils.py
@@ -21,35 +21,11 @@ from brachyutils.dose.dose_utils import BrachyDose
 # from brachyutils.egsphant_utils import BrachyEgsphant
 from brachyutils.geometry.applicator_utils import BrachyApplicator 
 from brachyutils.geometry.phantom_utils import BrachyPhantom
-from brachyutils.geometry.catheter_utils.catheter_table import CatheterTable
+from brachyutils.geometry.catheter_utils.catheter_table import CatheterTable, ExportConfig_Dose
 from brachyutils.planning.structure_utils import BrachyStructure
 from brachyutils.planning.simulation_utils import BrachySimulation
 from brachyutils.planning.optimization.optim_utils import Optimization_Config
 from pydantic import BaseModel, ConfigDict, Field, model_validator, computed_field
-
-class ExportConfig_Dose(BaseModel):
-    """
-    Configuration for exporting dose data from the plan.
-    """
-    model_config = ConfigDict(
-        arbitrary_types_allowed=True,
-        use_attribute_docstrings=True  # Enables auto-docs from Field desc [web:48]
-    )
-    dir_export: str | Path = Field(None, description="Directory where dose files are exported.")
-    name_combined: str = Field("combined", description="File name for combined dose output.")
-    file_extension: Literal[".seq.nrrd", ".3ddose"] = Field(
-        ".seq.nrrd", description="Allowed file extensions for dose files."
-    )
-    write_dose_rate_maps: bool = Field(
-        False, description="Whether to write individual dose rate maps to files."
-    )
-    multi_processing: bool = Field(
-        True, description="Enable multiprocessing for export (yes/no toggle)."
-    )
-    @computed_field
-    def pth_combined(self)->Path:
-        self.dir_export = Path(self.dir_export)
-        return self.dir_export/(self.name_combined+self.file_extension)
 
 class ExportConfig_PlanFile(BaseModel):
     """

--- a/brachyutils/planning/plan_utils.py
+++ b/brachyutils/planning/plan_utils.py
@@ -636,59 +636,6 @@ class BrachyPlan:
         if any(self.dose_rate_dict):
             self._calculate_combined_dose(time_diffs=time_diffs)
 
-    def _calculate_combined_dose(self, time_diffs=None):
-        """
-        ### Purpose:
-        - To calculate the combined dose by multiplying the dose rates with the dwell times.
-        The result is stored in the combined_dose attribute.
-        We require strict name matching between the dwell names and dose rate names!
-        ### Inputs:
-        - time_diffs: a dictionary of time differences for each dwell in the plan. 
-        This is used to update the combined dose if the dwell times are updated without
-        having to reload the dose rate maps. The keys of the dictionary should be in
-        the format "catheter_{catheter_index}_dwell_{dwell_index}" and the values
-        should be the time differences in seconds. If None, the combined dose will
-        be calculated using the current dwell times in the plan.
-        ### Outputs:
-        - None: but it needs the following attributes to be filled:
-        - self.dose_rate_dict
-        - self.catheter_table
-        ### Raises:
-            AssertionError: If the dose rate tensor or dwell times array is empty.
-        """
-        if not any(self.dose_rate_dict):
-            raise ValueError("dose rate tensor is empty. Run load_dose_rates()")
-        if self.combined_dose is None:
-            self.combined_dose = BrachyDose.dose_with_empty_grid_like(
-                list(self.dose_rate_dict.values())[0])        
-        if time_diffs is None:
-            self.combined_dose.dose_image.imageArray.fill(0)
-            for catheter in self.catheter_table:
-                for dwell in catheter.dwells:
-                        self.combined_dose.dose_image.imageArray += self.dose_rate_dict.get(
-                            # f"run_{catheter.index+1}_{dwell.index+1}_{int(dwell.angle)}.seq.nrrd"
-                            dwell.name_id
-                            ).dose_image.imageArray * dwell.time
-        else:
-            for dwell_key, time_diff in time_diffs.items():
-                #print(time_diffs.items())
-                #print(self.dose_rate_dict.items())
-                #if time_diff < 1e-3 :
-                #    continue
-                #print("################")
-                #print(f"dwell key {dwell_key}")
-                #print(f"time diff {time_diff}")
-                #print("############")
-                split_dwell_key = dwell_key.split("_")
-                #print(f"split_dwell_key {split_dwell_key}")
-                catheter_number = split_dwell_key[1]
-                dwell_number = split_dwell_key[3]
-                dose_rate_key = f"run_{catheter_number}_{dwell_number}_0.seq.nrrd"
-                #print(f"dose_rate_key {dose_rate_key}")
-                #print(f"calculate_combined_dose() time_diff {time_diff}")
-                self.combined_dose.dose_image.imageArray += (
-                    self.dose_rate_dict.get(dose_rate_key).dose_image.imageArray * time_diff)
-
     def set_dvh_metric_goals(self, dvh_metric_goals: Union[dict, Path]):
         r"""
         ### Purpose:

--- a/brachyutils/planning/plan_utils.py
+++ b/brachyutils/planning/plan_utils.py
@@ -338,6 +338,7 @@ class BrachyPlan:
                 dwells_near_ptv=kwargs.get("dwells_near_ptv", True),
                 )
         # load the dose rate dict if the path is provided
+        # XXX Continue debugging from here
         if dir_dose_rate is not None and combined_dose is None:
             self.catheter_table.load_dose_rates(
                 dir_dose_rate=dir_dose_rate,

--- a/brachyutils/tests/test_catheter_table.py
+++ b/brachyutils/tests/test_catheter_table.py
@@ -88,7 +88,7 @@ def test_loading_from_dicom():
     # cat_tab_json.info()
 
 def test_catheter():
-    from brachyutils.geometry.catheter_utils.catheter_table import Catheter, DwellPosition
+    from brachyutils.geometry.catheter_utils.catheter_table import Catheter
     # # create a catheter from tip and last dwell position
     new_catheter = Catheter(
         index=0,
@@ -102,7 +102,7 @@ def test_catheter():
         coordinates_on_1_axis,
         coordinates_on_1_axis,
         coordinates_on_1_axis], axis=-1)
-    new_catheter = Catheter(index = 0, points=points)
+    new_catheter = Catheter(index=0, digitization_points=points)
     print(new_catheter)
 
 def test_catheter_to_mrk_json():
@@ -117,7 +117,7 @@ def test_get_from_delivered_dwellpositions():
     pth_plan = glob(pth_dicom + "/RP*.dcm")[0]
     from brachyutils.geometry.catheter_utils.catheter_table import CatheterTable
     cat_table = CatheterTable(catheters_dict=pth_plan)
-    delivered_cat_table = cat_table.get_from_delivered_dwellpositions()
+    delivered_cat_table = CatheterTable(catheters_dict=pth_plan, from_delivered_dwellpositions=True)
     assert cat_table.num_catheters >= delivered_cat_table.num_catheters, "Test failed the number of catheters in the delivered table is not equal to the original table."
     assert cat_table.num_dwell_positions >= delivered_cat_table.num_dwell_positions, "Test failed the number of dwell positions in the delivered table is not equal to the original table."
 
@@ -166,9 +166,9 @@ def test_get_dwells_by_ids():
 if __name__ == "__main__":
     # test_dwells_catheters()
     # test_loading_from_dicom()
-    # test_catheter()
+    test_catheter()
     # test_catheter_to_mrk_json()
     # test_get_from_delivered_dwellpositions()
     # test_load_dose_rates()
     # test_export_dose()
-    test_get_dwells_by_ids()
+    # test_get_dwells_by_ids()

--- a/brachyutils/tests/test_catheter_table.py
+++ b/brachyutils/tests/test_catheter_table.py
@@ -1,9 +1,9 @@
 from glob import glob
 from pathlib import Path
 import numpy as np
+from brachyutils.geometry.catheter_utils.catheter_table import DwellPosition, Catheter, CatheterTable
 
-def test_catheter_table():
-    from brachyutils.geometry.catheter_utils.catheter_table import DwellPosition, Catheter, CatheterTable
+def test_dwells_catheters():
     dwell_dict_0 = {
         "index": 0,
         "position": np.random.rand(3), 
@@ -45,7 +45,8 @@ def test_catheter_table():
     }
     catheter_obj = Catheter(**catheter_dict)
     print(catheter_obj.to_dict())
-
+    
+def test_loading_from_dicom():
     # # test loadin from dicom
     pth_dicom = "data_test/prostate-glen-p1-dcm"
     pth_json_delivered = "data_test/test_export_plan/prostate/cat_table_delivered.mrk.json"
@@ -122,7 +123,8 @@ def test_get_from_delivered_dwellpositions():
 
 
 if __name__ == "__main__":
-    test_catheter_table()
+    # test_dwells_catheters()
+    test_loading_from_dicom()
     # test_catheter()
     # test_catheter_to_mrk_json()
     # test_get_from_delivered_dwellpositions()

--- a/brachyutils/tests/test_catheter_table.py
+++ b/brachyutils/tests/test_catheter_table.py
@@ -159,7 +159,7 @@ def test_get_dwells_by_ids():
     dwell_ids = [
         "0_3_0", "8_4_0", "1_1_0",
     ]
-    dwells_got = cat_tab_to_export.get_dwell_by_name_ids(dwell_ids)
+    dwells_got = cat_tab_to_export.get_dwells_by_name_ids(dwell_ids)
     for dwell in dwells_got:
         print(dwell.name_id)
     

--- a/brachyutils/tests/test_catheter_table.py
+++ b/brachyutils/tests/test_catheter_table.py
@@ -121,7 +121,7 @@ def test_get_from_delivered_dwellpositions():
     assert cat_table.num_catheters >= delivered_cat_table.num_catheters, "Test failed the number of catheters in the delivered table is not equal to the original table."
     assert cat_table.num_dwell_positions >= delivered_cat_table.num_dwell_positions, "Test failed the number of dwell positions in the delivered table is not equal to the original table."
 
-def test_load_dose_rates():
+def test_load_dose_rates() -> CatheterTable:
     dir_dicom = Path("data_test/prostate-glen-p1-dcm")
     dir_dose_rates = Path("data_test/prostate-glen-p1-dose")
 
@@ -142,7 +142,17 @@ def test_load_dose_rates():
     cat_tab.load_dose_rates(
         dir_dose_rate=dir_dose_rates
     )
-    print(cat_tab.combined_dose.dose_image.imageArray.mean())
+    return cat_tab
+
+def test_export_dose():
+    dir_export = "data_test/test_export_plan/prostate"
+    cat_tab_to_export = test_load_dose_rates()
+    from brachyutils.geometry.catheter_utils.catheter_table import ExportConfig_Dose    
+    dose_export_config = ExportConfig_Dose(
+        dir_export=dir_export,
+        write_dose_rate_maps=True
+    )
+    cat_tab_to_export.export_dose(dose_export_config)
 
 if __name__ == "__main__":
     # test_dwells_catheters()
@@ -150,4 +160,5 @@ if __name__ == "__main__":
     # test_catheter()
     # test_catheter_to_mrk_json()
     # test_get_from_delivered_dwellpositions()
-    test_load_dose_rates()
+    # test_load_dose_rates()
+    test_export_dose()

--- a/brachyutils/tests/test_catheter_table.py
+++ b/brachyutils/tests/test_catheter_table.py
@@ -129,9 +129,21 @@ def test_load_dose_rates():
         catheter_list=list(dir_dicom.glob("RP*.dcm"))[0],
         from_delivered_dwellpositions=False
     )
+    
+    from brachyutils.geometry.phantom_utils import BrachyPhantom
+    phant = BrachyPhantom(
+        dir_dicom=dir_dicom,
+        pth_structures_file=list(dir_dicom.glob("RS*.dcm"))[0],)
+    ptv_mask = phant.get_structure_mask(["CTV"], strict_name_match=False).popitem()[-1]
+    cat_tab.remove_outside_mask(
+            mask=ptv_mask,
+            margin_mm=5
+        )
     cat_tab.load_dose_rates(
         dir_dose_rate=dir_dose_rates
     )
+    print(cat_tab.combined_dose.dose_image.imageArray.mean())
+
 if __name__ == "__main__":
     # test_dwells_catheters()
     # test_loading_from_dicom()

--- a/brachyutils/tests/test_catheter_table.py
+++ b/brachyutils/tests/test_catheter_table.py
@@ -121,10 +121,21 @@ def test_get_from_delivered_dwellpositions():
     assert cat_table.num_catheters >= delivered_cat_table.num_catheters, "Test failed the number of catheters in the delivered table is not equal to the original table."
     assert cat_table.num_dwell_positions >= delivered_cat_table.num_dwell_positions, "Test failed the number of dwell positions in the delivered table is not equal to the original table."
 
+def test_load_dose_rates():
+    dir_dicom = Path("data_test/prostate-glen-p1-dcm")
+    dir_dose_rates = Path("data_test/prostate-glen-p1-dose")
 
+    cat_tab = CatheterTable(
+        catheter_list=list(dir_dicom.glob("RP*.dcm"))[0],
+        from_delivered_dwellpositions=False
+    )
+    cat_tab.load_dose_rates(
+        dir_dose_rate=dir_dose_rates
+    )
 if __name__ == "__main__":
     # test_dwells_catheters()
-    test_loading_from_dicom()
+    # test_loading_from_dicom()
     # test_catheter()
     # test_catheter_to_mrk_json()
     # test_get_from_delivered_dwellpositions()
+    test_load_dose_rates()

--- a/brachyutils/tests/test_catheter_table.py
+++ b/brachyutils/tests/test_catheter_table.py
@@ -55,13 +55,13 @@ def test_loading_from_dicom():
 
     pth_plan = glob(pth_dicom + "/RP*.dcm")[0]
     catheter_table_delivered = CatheterTable(
-        catheter_list=pth_plan,
+        catheters_dict=pth_plan,
         from_delivered_dwellpositions=True)
     catheter_table_delivered.write_to_slicer_markup(
         pth_mrk_json=pth_json_delivered
     )
     catheter_table_all = CatheterTable(
-        catheter_list=pth_plan,
+        catheters_dict=pth_plan,
         from_delivered_dwellpositions=False)
     catheter_table_all.write_to_slicer_markup(
         pth_mrk_json=pth_json_all
@@ -74,7 +74,7 @@ def test_loading_from_dicom():
         pth_structures_file=glob(pth_dicom + "/RS*.dcm")[0])
     ptv_mask = phant.get_structure_mask(["CTV"], strict_name_match=False).popitem()[-1]
     catheter_table_all_in_ptv = CatheterTable(
-        catheter_list=pth_plan,
+        catheters_dict=pth_plan,
         from_delivered_dwellpositions=True)
     catheter_table_all_in_ptv.remove_outside_mask(
             mask=ptv_mask,
@@ -84,7 +84,7 @@ def test_loading_from_dicom():
         pth_mrk_json=pth_json_all_in_ptv
     )
 
-    # cat_tab_json = CatheterTable(catheter_list=pth_json)
+    # cat_tab_json = CatheterTable(catheters_dict=pth_json)
     # cat_tab_json.info()
 
 def test_catheter():
@@ -109,14 +109,14 @@ def test_catheter_to_mrk_json():
     from brachyutils.geometry.catheter_utils.catheter_table import CatheterTable
     pth_dicom = Path("data_test/prostate-glen-p1-dcm").resolve()
     pth_out = "data_test/test_export_plan/prostate/test_catheter_table.mrk.json"
-    cat_table = CatheterTable(catheter_list=list(pth_dicom.glob("RP*.dcm"))[0])
+    cat_table = CatheterTable(catheters_dict=list(pth_dicom.glob("RP*.dcm"))[0])
     cat_table.write_to_slicer_markup(pth_mrk_json=pth_out)
 
 def test_get_from_delivered_dwellpositions():
     pth_dicom = "data_test/prostate-glen-p1-dcm"
     pth_plan = glob(pth_dicom + "/RP*.dcm")[0]
     from brachyutils.geometry.catheter_utils.catheter_table import CatheterTable
-    cat_table = CatheterTable(catheter_list=pth_plan)
+    cat_table = CatheterTable(catheters_dict=pth_plan)
     delivered_cat_table = cat_table.get_from_delivered_dwellpositions()
     assert cat_table.num_catheters >= delivered_cat_table.num_catheters, "Test failed the number of catheters in the delivered table is not equal to the original table."
     assert cat_table.num_dwell_positions >= delivered_cat_table.num_dwell_positions, "Test failed the number of dwell positions in the delivered table is not equal to the original table."
@@ -126,7 +126,7 @@ def test_load_dose_rates() -> CatheterTable:
     dir_dose_rates = Path("data_test/prostate-glen-p1-dose")
 
     cat_tab = CatheterTable(
-        catheter_list=list(dir_dicom.glob("RP*.dcm"))[0],
+        catheters_dict=list(dir_dicom.glob("RP*.dcm"))[0],
         from_delivered_dwellpositions=False
     )
     

--- a/brachyutils/tests/test_catheter_table.py
+++ b/brachyutils/tests/test_catheter_table.py
@@ -154,6 +154,15 @@ def test_export_dose():
     )
     cat_tab_to_export.export_dose(dose_export_config)
 
+def test_get_dwells_by_ids():
+    cat_tab_to_export = test_load_dose_rates()
+    dwell_ids = [
+        "0_3_0", "8_4_0", "1_1_0",
+    ]
+    dwells_got = cat_tab_to_export.get_dwell_by_name_ids(dwell_ids)
+    for dwell in dwells_got:
+        print(dwell.name_id)
+    
 if __name__ == "__main__":
     # test_dwells_catheters()
     # test_loading_from_dicom()
@@ -161,4 +170,5 @@ if __name__ == "__main__":
     # test_catheter_to_mrk_json()
     # test_get_from_delivered_dwellpositions()
     # test_load_dose_rates()
-    test_export_dose()
+    # test_export_dose()
+    test_get_dwells_by_ids()

--- a/brachyutils/tests/test_catheter_table.py
+++ b/brachyutils/tests/test_catheter_table.py
@@ -1,0 +1,128 @@
+from glob import glob
+from pathlib import Path
+import numpy as np
+
+def test_catheter_table():
+    from brachyutils.geometry.catheter_utils.catheter_table import DwellPosition, Catheter, CatheterTable
+    dwell_dict_0 = {
+        "index": 0,
+        "position": np.random.rand(3), 
+        "relativePos": 5,
+        'rotation': [0.0, 0.0, 0.0],
+        "time": 45.3,
+        "catheter_index":0,
+    }
+    dwell_dict_1 = {
+        "index": 1,
+        # "angle": 0,
+        "position": np.random.rand(3), 
+        "relativePos": 5,
+        'rotation': [0.0, 0.0, 0.0],
+        "time": np.random.rand(1) * 100,
+        "catheter_index":0,
+    }
+    dwell_dict_2 = {
+        "index": 2,
+        "angle": 180,
+        "position": np.random.rand(3), 
+        "relativePos": 5,
+        'rotation': [0.0, 0.0, 0.0],
+        "time": np.random.rand(1) * 100,
+        "catheter_index":0,
+    }
+    dwell_obj = DwellPosition(**dwell_dict_0)
+    print(dwell_obj.to_dict())
+    
+    catheter_dict = {
+        "index": 0,
+        "dwells": [
+            dwell_dict_0,
+            dwell_dict_1,
+            dwell_dict_2,
+        ],
+        "points" :[],
+        "afterloader_channel_number": 0,
+    }
+    catheter_obj = Catheter(**catheter_dict)
+    print(catheter_obj.to_dict())
+
+    # # test loadin from dicom
+    pth_dicom = "data_test/prostate-glen-p1-dcm"
+    pth_json_delivered = "data_test/test_export_plan/prostate/cat_table_delivered.mrk.json"
+    pth_json_all = "data_test/test_export_plan/prostate/cat_table_all.mrk.json"
+    pth_json_all_in_ptv = "data_test/test_export_plan/prostate/cat_table_all_in_ptv.mrk.json"
+
+    pth_plan = glob(pth_dicom + "/RP*.dcm")[0]
+    catheter_table_delivered = CatheterTable(
+        catheter_list=pth_plan,
+        from_delivered_dwellpositions=True)
+    catheter_table_delivered.write_to_slicer_markup(
+        pth_mrk_json=pth_json_delivered
+    )
+    catheter_table_all = CatheterTable(
+        catheter_list=pth_plan,
+        from_delivered_dwellpositions=False)
+    catheter_table_all.write_to_slicer_markup(
+        pth_mrk_json=pth_json_all
+    )
+
+    # get the mask of the ptv
+    from brachyutils.geometry.phantom_utils import BrachyPhantom
+    phant = BrachyPhantom(
+        dir_dicom=pth_dicom,
+        pth_structures_file=glob(pth_dicom + "/RS*.dcm")[0])
+    ptv_mask = phant.get_structure_mask(["CTV"], strict_name_match=False).popitem()[-1]
+    catheter_table_all_in_ptv = CatheterTable(
+        catheter_list=pth_plan,
+        from_delivered_dwellpositions=True)
+    catheter_table_all_in_ptv.remove_outside_mask(
+            mask=ptv_mask,
+            margin_mm=10
+        )
+    catheter_table_all_in_ptv.write_to_slicer_markup(
+        pth_mrk_json=pth_json_all_in_ptv
+    )
+
+    # cat_tab_json = CatheterTable(catheter_list=pth_json)
+    # cat_tab_json.info()
+
+def test_catheter():
+    from brachyutils.geometry.catheter_utils.catheter_table import Catheter, DwellPosition
+    # # create a catheter from tip and last dwell position
+    new_catheter = Catheter(
+        index=0,
+        tip_position=[25, 25, 25],
+        last_dwell_coordinate=[0, 0, 0]
+    )
+    print(new_catheter)
+    # create a catheter from digitization points
+    coordinates_on_1_axis = np.arange(53, 1.5, -2)
+    points = np.stack([
+        coordinates_on_1_axis,
+        coordinates_on_1_axis,
+        coordinates_on_1_axis], axis=-1)
+    new_catheter = Catheter(index = 0, points=points)
+    print(new_catheter)
+
+def test_catheter_to_mrk_json():
+    from brachyutils.geometry.catheter_utils.catheter_table import CatheterTable
+    pth_dicom = Path("data_test/prostate-glen-p1-dcm").resolve()
+    pth_out = "data_test/test_export_plan/prostate/test_catheter_table.mrk.json"
+    cat_table = CatheterTable(catheter_list=list(pth_dicom.glob("RP*.dcm"))[0])
+    cat_table.write_to_slicer_markup(pth_mrk_json=pth_out)
+
+def test_get_from_delivered_dwellpositions():
+    pth_dicom = "data_test/prostate-glen-p1-dcm"
+    pth_plan = glob(pth_dicom + "/RP*.dcm")[0]
+    from brachyutils.geometry.catheter_utils.catheter_table import CatheterTable
+    cat_table = CatheterTable(catheter_list=pth_plan)
+    delivered_cat_table = cat_table.get_from_delivered_dwellpositions()
+    assert cat_table.num_catheters >= delivered_cat_table.num_catheters, "Test failed the number of catheters in the delivered table is not equal to the original table."
+    assert cat_table.num_dwell_positions >= delivered_cat_table.num_dwell_positions, "Test failed the number of dwell positions in the delivered table is not equal to the original table."
+
+
+if __name__ == "__main__":
+    test_catheter_table()
+    # test_catheter()
+    # test_catheter_to_mrk_json()
+    # test_get_from_delivered_dwellpositions()

--- a/brachyutils/tests/test_dose_generation_utils.py
+++ b/brachyutils/tests/test_dose_generation_utils.py
@@ -90,9 +90,23 @@ def test_DoseMC():
         random_seed=1,
     )
 
+def test_run_dose_gen_tg43():
+    from brachyutils.tests.test_plan_utils import get_a_plan
+    pth_dicom = Path("data_test/prostate-glen-p1-dcm").resolve()
+    dir_export = Path("temp_data/tg43")/pth_dicom.stem
+    plan_obj = get_a_plan(
+        pth_dicom=pth_dicom,
+    )
+    dose_gen = DoseTG43(
+        dir_plan_export=dir_export
+    )
+    dose_gen.run_dose_generation(
+        plan=plan_obj,
+    )
+    # test the case with only combined dose
 
 if __name__ == "__main__":
-    test_DoseTG43()
+    # test_DoseTG43()
     # test_DoseMC()
     # import requests
 
@@ -108,3 +122,5 @@ if __name__ == "__main__":
     # response = requests.post("http://192.168.1.12:8000/calculate_dose_tg43", json=json_data, timeout=None)
 
     # print(response.json())
+
+    test_run_dose_gen_tg43()

--- a/brachyutils/tests/test_geometry_utils.py
+++ b/brachyutils/tests/test_geometry_utils.py
@@ -135,116 +135,6 @@ def test_crop_phantom():
     phantom_obj.write_image_to_nrrd(pth_out + "/test_ct.nrrd")
     phantom_obj.write_structures_to_nrrd(pth_out + "/test_rs.seg.nrrd")
 
-
-def test_catheter_table():
-    from brachyutils.geometry.catheter_utils.catheter_table import DwellPosition, Catheter, CatheterTable
-    dwell_dict_0 = {
-        "index": 0,
-        "position": np.random.rand(3), 
-        "relativePos": 5,
-        'rotation': [0.0, 0.0, 0.0],
-        "time": 45.3,
-        "catheter_index":0,
-    }
-    dwell_dict_1 = {
-        "index": 1,
-        # "angle": 0,
-        "position": np.random.rand(3), 
-        "relativePos": 5,
-        'rotation': [0.0, 0.0, 0.0],
-        "time": np.random.rand(1) * 100,
-        "catheter_index":0,
-    }
-    dwell_dict_2 = {
-        "index": 2,
-        "angle": 180,
-        "position": np.random.rand(3), 
-        "relativePos": 5,
-        'rotation': [0.0, 0.0, 0.0],
-        "time": np.random.rand(1) * 100,
-        "catheter_index":0,
-    }
-    dwell_obj = DwellPosition(**dwell_dict_0)
-    print(dwell_obj.to_dict())
-    
-    catheter_dict = {
-        "index": 0,
-        "dwells": [
-            dwell_dict_0,
-            dwell_dict_1,
-            dwell_dict_2,
-        ],
-        "points" :[],
-        "afterloader_channel_number": 0,
-    }
-    catheter_obj = Catheter(**catheter_dict)
-    print(catheter_obj.to_dict())
-
-    # # test loadin from dicom
-    pth_dicom = "data_test/prostate-glen-p1-dcm"
-    pth_json_delivered = "data_test/test_export_plan/prostate/cat_table_delivered.mrk.json"
-    pth_json_all = "data_test/test_export_plan/prostate/cat_table_all.mrk.json"
-    pth_json_all_in_ptv = "data_test/test_export_plan/prostate/cat_table_all_in_ptv.mrk.json"
-
-    pth_plan = glob(pth_dicom + "/RP*.dcm")[0]
-    catheter_table_delivered = CatheterTable(
-        catheter_list=pth_plan,
-        from_delivered_dwellpositions=True)
-    catheter_table_delivered.write_to_slicer_markup(
-        pth_mrk_json=pth_json_delivered
-    )
-    catheter_table_all = CatheterTable(
-        catheter_list=pth_plan,
-        from_delivered_dwellpositions=False)
-    catheter_table_all.write_to_slicer_markup(
-        pth_mrk_json=pth_json_all
-    )
-
-    # get the mask of the ptv
-    from brachyutils.geometry.phantom_utils import BrachyPhantom
-    phant = BrachyPhantom(
-        dir_dicom=pth_dicom,
-        pth_structures_file=glob(pth_dicom + "/RS*.dcm")[0])
-    ptv_mask = phant.get_structure_mask(["CTV"], strict_name_match=False).popitem()[-1]
-    catheter_table_all_in_ptv = CatheterTable(
-        catheter_list=pth_plan,
-        from_delivered_dwellpositions=True)
-    catheter_table_all_in_ptv.remove_outside_mask(
-            mask=ptv_mask,
-            margin_mm=10
-        )
-    catheter_table_all_in_ptv.write_to_slicer_markup(
-        pth_mrk_json=pth_json_all_in_ptv
-    )
-
-    # cat_tab_json = CatheterTable(catheter_list=pth_json)
-    # cat_tab_json.info()
-
-def test_catheter():
-    from brachyutils.geometry.catheter_utils.catheter_table import Catheter, DwellPosition
-    # # create a catheter from tip and last dwell position
-    new_catheter = Catheter(
-        index=0,
-        tip_position=[25, 25, 25],
-        last_dwell_coordinate=[0, 0, 0]
-    )
-    print(new_catheter)
-    # create a catheter from digitization points
-    coordinates_on_1_axis = np.arange(53, 1.5, -2)
-    points = np.stack([
-        coordinates_on_1_axis,
-        coordinates_on_1_axis,
-        coordinates_on_1_axis], axis=-1)
-    new_catheter = Catheter(index = 0, points=points)
-    print(new_catheter)
-
-def test_catheter_to_mrk_json():
-    from brachyutils.geometry.catheter_utils.catheter_table import CatheterTable
-    pth_dicom = Path("data_test/prostate-glen-p1-dcm").resolve()
-    pth_out = "data_test/test_export_plan/prostate/test_catheter_table.mrk.json"
-    cat_table = CatheterTable(catheter_list=list(pth_dicom.glob("RP*.dcm"))[0])
-    cat_table.write_to_slicer_markup(pth_mrk_json=pth_out)
-
 def test_BrachyApplicator():
     pth_applicator_stl = "data_test/rectal-jgh-planFiles/applicator_0.stl"
     applicator_obj = BrachyApplicator(pth_applicator_stl)
@@ -384,16 +274,6 @@ def test_dicom_rt_tools():
 
     phantom_obj.export_to(dir_nrrd_out=pth_out)
 
-
-def test_get_from_delivered_dwellpositions():
-    pth_dicom = "data_test/prostate-glen-p1-dcm"
-    pth_plan = glob(pth_dicom + "/RP*.dcm")[0]
-    from brachyutils.geometry.catheter_utils.catheter_table import CatheterTable
-    cat_table = CatheterTable(catheter_list=pth_plan)
-    delivered_cat_table = cat_table.get_from_delivered_dwellpositions()
-    assert cat_table.num_catheters >= delivered_cat_table.num_catheters, "Test failed the number of catheters in the delivered table is not equal to the original table."
-    assert cat_table.num_dwell_positions >= delivered_cat_table.num_dwell_positions, "Test failed the number of dwell positions in the delivered table is not equal to the original table."
-
 def test_generate_sphere_mask():
     from brachyutils.geometry.phantom_utils import generate_sphere_mask
     center = np.array([15, 5, 5])
@@ -416,7 +296,7 @@ def test_load_pet_dicom():
 
 if __name__ == "__main__":
     # print("testing BrachyPhantom")
-    # test_brachy_phantom()
+    test_brachy_phantom()
     # test_get_structure_mask()
     # test_write_image_to_dicom()
     # test_write_image_to_nrrd()
@@ -436,9 +316,5 @@ if __name__ == "__main__":
     # test_load_nifti_image_and_segmentation_file()
     # test_resample_to()
     # test_dicom_rt_tools()
-    test_catheter_table()
-    # test_catheter()
-    # test_catheter_to_mrk_json()
-    # test_get_from_delivered_dwellpositions()
     # test_generate_sphere_mask()
     # test_load_pet_dicom()

--- a/brachyutils/tests/test_geometry_utils.py
+++ b/brachyutils/tests/test_geometry_utils.py
@@ -142,7 +142,7 @@ def test_catheter_table():
         "index": 0,
         "position": np.random.rand(3), 
         "relativePos": 5,
-        'rotation': {'x': 0.0, 'y': 0.0, 'z': 0.0},
+        'rotation': [0.0, 0.0, 0.0],
         "time": 45.3,
         "catheter_index":0,
     }
@@ -151,7 +151,7 @@ def test_catheter_table():
         # "angle": 0,
         "position": np.random.rand(3), 
         "relativePos": 5,
-        'rotation': {'x': 0.0, 'y': 0.0, 'z': 0.0},
+        'rotation': [0.0, 0.0, 0.0],
         "time": np.random.rand(1) * 100,
         "catheter_index":0,
     }
@@ -160,7 +160,7 @@ def test_catheter_table():
         "angle": 180,
         "position": np.random.rand(3), 
         "relativePos": 5,
-        'rotation': {'x': 0.0, 'y': 0.0, 'z': 0.0},
+        'rotation': [0.0, 0.0, 0.0],
         "time": np.random.rand(1) * 100,
         "catheter_index":0,
     }

--- a/brachyutils/tests/test_geometry_utils.py
+++ b/brachyutils/tests/test_geometry_utils.py
@@ -140,12 +140,11 @@ def test_catheter_table():
     from brachyutils.geometry.catheter_utils.catheter_table import DwellPosition, Catheter, CatheterTable
     dwell_dict_0 = {
         "index": 0,
-        # "angle": 0,
         "position": np.random.rand(3), 
         "relativePos": 5,
         'rotation': {'x': 0.0, 'y': 0.0, 'z': 0.0},
         "time": 45.3,
-        # "weight": 0.003,
+        "catheter_index":0,
     }
     dwell_dict_1 = {
         "index": 1,
@@ -154,7 +153,7 @@ def test_catheter_table():
         "relativePos": 5,
         'rotation': {'x': 0.0, 'y': 0.0, 'z': 0.0},
         "time": np.random.rand(1) * 100,
-        # "weight": 0.003,
+        "catheter_index":0,
     }
     dwell_dict_2 = {
         "index": 2,
@@ -163,7 +162,7 @@ def test_catheter_table():
         "relativePos": 5,
         'rotation': {'x': 0.0, 'y': 0.0, 'z': 0.0},
         "time": np.random.rand(1) * 100,
-        # "weight": 0.003,
+        "catheter_index":0,
     }
     dwell_obj = DwellPosition(**dwell_dict_0)
     print(dwell_obj.to_dict())

--- a/brachyutils/tests/test_optim_catheters.py
+++ b/brachyutils/tests/test_optim_catheters.py
@@ -123,7 +123,7 @@ def test_dynamic_plan_generation():
     # # now split this catheter table into two.
     cat_table_p1 = full_cat_table[:len(full_cat_table)//2]
     cat_table_p2 = full_cat_table[len(full_cat_table)//2:]
-    cat_table_p2.reset_index()
+    # cat_table_p2.reset_index()
     # cat_table_p1.info()
     # cat_table_p2.info()
 

--- a/brachyutils/tests/test_optim_catheters.py
+++ b/brachyutils/tests/test_optim_catheters.py
@@ -11,7 +11,7 @@ from brachyutils.dose.dose_generation_utils import DoseTG43
 def test_catheter_gurobi_initialization():
     # we need a catheter table first!
     pth_dicom = Path("data_test/prostate-glen-p1-dcm").resolve()
-    cat_table = CatheterTable(catheter_list=list(pth_dicom.glob("RP*.dcm"))[0])
+    cat_table = CatheterTable(catheters_dict=list(pth_dicom.glob("RP*.dcm"))[0])
 
     catheter_vars = []
     model = Model("test_model")
@@ -119,7 +119,7 @@ def test_dynamic_plan_generation():
         content_to_export=init_export_config
     )
     # # get the full catheter table.
-    full_cat_table = CatheterTable(catheter_list=list(pth_dicom.glob("RP*.dcm"))[0])
+    full_cat_table = CatheterTable(catheters_dict=list(pth_dicom.glob("RP*.dcm"))[0])
     # # now split this catheter table into two.
     cat_table_p1 = full_cat_table[:len(full_cat_table)//2]
     cat_table_p2 = full_cat_table[len(full_cat_table)//2:]

--- a/brachyutils/tests/test_optim_catheters.py
+++ b/brachyutils/tests/test_optim_catheters.py
@@ -133,58 +133,48 @@ def test_dynamic_plan_generation():
     )
     # plan.catheter_table.info()
     # # now generate dose rates for the first half of the catheters.
-    export_for_dose = {
-        "dir_export": dir_dose_rates,
-        "export_config_macfile": {
-            "name_combined": "cat_p1"
-        },
-        "export_config_planfile": {
-            "name_combined": "cat_p1"
-        }
-    }
-    # initialize the dose generator object
+    # # initialize the dose generator object
     dose_generator = DoseTG43(
         dir_plan_export=dir_dose_rates
     )
-
-    plan.export_brachy_plan(
-        content_to_export=export_for_dose
-    )
-
-    dose_generator.generate_dose(
-        pth_mac=dir_dose_rates/"cat_p1.mac",
-        pth_egsphant=dir_dose_rates/"egsphant.seq.nrrd",
-        pth_plan=dir_dose_rates/"cat_p1.plan",
-        output_dose_per_dwell="dose_rate")
-
-    plan.load_dose_rates(
-        dir_dose_rate=dir_dose_rates,
-    )
-
-    plan.set_catheter_table(
-        catheter_table=cat_table_p1+cat_table_p2,        
-    )
-    export_for_dose = {
-        "dir_export": dir_dose_rates,
-        "export_config_macfile": {
-            "name_combined": "cat_p2"
-        },
-        "export_config_planfile": {
-            "name_combined": "cat_p2"
+    plan = dose_generator.run_dose_generation(
+        plan=plan,
+        generate_dose_rate_maps=True,
+        export_config_brachyplan={
+            "dir_export": dir_dose_rates,
+            "export_config_macfile": {
+                "name_combined": "cat_p1"
+            },
+            "export_config_planfile": {
+                "name_combined": "cat_p1"
+            }
         }
-    }
-    plan.export_brachy_plan(
-        content_to_export=export_for_dose
     )
-    dose_generator.generate_dose(
-        pth_mac=dir_dose_rates/"cat_p2.mac",
-        pth_egsphant=dir_dose_rates/"egsphant.seq.nrrd",
-        pth_plan=dir_dose_rates/"cat_p2.plan",
-        output_dose_per_dwell="dose_rate")
 
-    plan.load_dose_rates(
-        dir_dose_rate=dir_dose_rates,
-    )
+    # plan.set_catheter_table(
+    #     catheter_table=cat_table_p1+cat_table_p2,        
+    # )
+    # export_for_dose = {
+    #     "dir_export": dir_dose_rates,
+    #     "export_config_macfile": {
+    #         "name_combined": "cat_p2"
+    #     },
+    #     "export_config_planfile": {
+    #         "name_combined": "cat_p2"
+    #     }
+    # }
+    # plan.export_brachy_plan(
+    #     content_to_export=export_for_dose
+    # )
+    # dose_generator.generate_dose(
+    #     pth_mac=dir_dose_rates/"cat_p2.mac",
+    #     pth_egsphant=dir_dose_rates/"egsphant.seq.nrrd",
+    #     pth_plan=dir_dose_rates/"cat_p2.plan",
+    #     output_dose_per_dwell="dose_rate")
+
+    # plan.load_dose_rates(
+    #     dir_dose_rate=dir_dose_rates,
+    # )
     print("debug here")
 
 

--- a/brachyutils/tests/test_optim_catheters.py
+++ b/brachyutils/tests/test_optim_catheters.py
@@ -151,30 +151,23 @@ def test_dynamic_plan_generation():
         }
     )
 
-    # plan.set_catheter_table(
-    #     catheter_table=cat_table_p1+cat_table_p2,        
-    # )
-    # export_for_dose = {
-    #     "dir_export": dir_dose_rates,
-    #     "export_config_macfile": {
-    #         "name_combined": "cat_p2"
-    #     },
-    #     "export_config_planfile": {
-    #         "name_combined": "cat_p2"
-    #     }
-    # }
-    # plan.export_brachy_plan(
-    #     content_to_export=export_for_dose
-    # )
-    # dose_generator.generate_dose(
-    #     pth_mac=dir_dose_rates/"cat_p2.mac",
-    #     pth_egsphant=dir_dose_rates/"egsphant.seq.nrrd",
-    #     pth_plan=dir_dose_rates/"cat_p2.plan",
-    #     output_dose_per_dwell="dose_rate")
+    plan.set_catheter_table(
+        catheter_table=cat_table_p1+cat_table_p2,        
+    )
+    plan = dose_generator.run_dose_generation(
+        plan=plan,
+        generate_dose_rate_maps=True,
+        export_config_brachyplan={
+            "dir_export": dir_dose_rates,
+            "export_config_macfile": {
+                "name_combined": "cat_p2"
+            },
+            "export_config_planfile": {
+                "name_combined": "cat_p2"
+            }
+        }
+    )
 
-    # plan.load_dose_rates(
-    #     dir_dose_rate=dir_dose_rates,
-    # )
     print("debug here")
 
 

--- a/brachyutils/tests/test_optim_catheters.py
+++ b/brachyutils/tests/test_optim_catheters.py
@@ -167,7 +167,8 @@ def test_dynamic_plan_generation():
             }
         }
     )
-
+    plan.catheter_table.write_to_slicer_markup(dir_dose_rates/"catheter_table.mrk.json")
+    plan.combined_dose.write_to_nrrd(dir_dose_rates/"combined_dose.seq.nrrd")
     print("debug here")
 
 

--- a/brachyutils/tests/test_optim_catheters.py
+++ b/brachyutils/tests/test_optim_catheters.py
@@ -157,7 +157,7 @@ def test_dynamic_plan_generation():
         pth_plan=dir_dose_rates/"cat_p1.plan",
         output_dose_per_dwell="dose_rate")
 
-    plan.load_dose_rate_dict(
+    plan.load_dose_rates(
         dir_dose_rate=dir_dose_rates,
     )
 
@@ -182,7 +182,7 @@ def test_dynamic_plan_generation():
         pth_plan=dir_dose_rates/"cat_p2.plan",
         output_dose_per_dwell="dose_rate")
 
-    plan.load_dose_rate_dict(
+    plan.load_dose_rates(
         dir_dose_rate=dir_dose_rates,
     )
     print("debug here")

--- a/brachyutils/tests/test_optim_utils.py
+++ b/brachyutils/tests/test_optim_utils.py
@@ -79,7 +79,7 @@ def get_a_plan_to_optimize(
             output_dose_per_dwell="dose_rate"
         )
 
-    plan_obj.load_dose_rate_dict(
+    plan_obj.load_dose_rates(
         dir_dose_rate=dir_dose_rates,
         multi_processing=True,
     )

--- a/brachyutils/tests/test_plan_utils.py
+++ b/brachyutils/tests/test_plan_utils.py
@@ -69,7 +69,7 @@ def test_load_dose_rate_dict():
     dir_dose_rate = "data_test/prostate-glen-p1-dose"
 
     catheter_table = CatheterTable(
-        catheter_list=pth_plan,
+        catheters_dict=pth_plan,
         from_delivered_dwellpositions=True,
     )
     plan_obj = BrachyPlan(
@@ -119,7 +119,7 @@ def test_calculate_combined_uncertainty():
     dir_dose_rate = "data_test/prostate-glen-p1-dose"
 
     catheter_table = CatheterTable(
-        catheter_list=pth_plan,
+        catheters_dict=pth_plan,
         from_delivered_dwellpositions=True,
     )
     plan_obj = BrachyPlan(

--- a/brachyutils/tests/test_plan_utils.py
+++ b/brachyutils/tests/test_plan_utils.py
@@ -338,7 +338,6 @@ def test_run_dose_generation():
         pth_dicom=pth_dicom,
     )
     # test the case with only combined dose
-    # XXX pick up here!
     plan_obj.run_dose_generation()
     print("debug here")
 if __name__ == "__main__":

--- a/brachyutils/tests/test_plan_utils.py
+++ b/brachyutils/tests/test_plan_utils.py
@@ -9,17 +9,17 @@ from brachyutils.planning.plan_utils import BrachyPlan
 from brachyutils.planning.plan_utils import load_dicom_to_plan
 def get_a_plan(
     pth_dicom:str | Path,
+    prescription_dose:float=21.0,
     **kwargs):
-    target_dose = 21.0
     dvh_metric_goals = {
-        "D90%(CTV)": target_dose,
-        "D2cc(RECTUM)": target_dose * 0.75,
-        "D10%(URETHRA)": target_dose * 1.133,
-        "D30%(URETHRA)": target_dose,
+        "D90%(CTV)": prescription_dose,
+        "D2cc(RECTUM)": prescription_dose * 0.75,
+        "D10%(URETHRA)": prescription_dose * 1.133,
+        "D30%(URETHRA)": prescription_dose,
         "CI(CTV)": 1.0,
         "HI(CTV)": 0.5,
-        "V200%(CTV)": target_dose * 0.2,
-        "V150%(CTV)": target_dose * 0.4,
+        "V200%(CTV)": prescription_dose * 0.2,
+        "V150%(CTV)": prescription_dose * 0.4,
         "V100%(CTV)": 100.0,
     }
 
@@ -28,9 +28,9 @@ def get_a_plan(
         load_dicom_dose=kwargs.get("load_dicom_dose", False),
         load_dicom_catheter_table=kwargs.get("load_dicom_catheter_table", True),
         strict_name_match=False,
-        from_delivered_dwellpositions=kwargs.get("from_delivered_dwellpositions", True),
+        from_delivered_dwellpositions=kwargs.get("from_delivered_dwellpositions", False),
         multi_processing=True,
-        prescription_dose=target_dose,
+        prescription_dose=prescription_dose,
         dvh_metric_goals=dvh_metric_goals,
         optimization_config_list=kwargs.get("optimization_config_list", None),
         dwells_near_ptv=True,
@@ -186,13 +186,6 @@ def test_BrachyPlan():
         "data_test/test_export_plan/prostate/combined.seq.nrrd"
     )
 
-
-def test__load_single_dose_or_uncertainty_to_dict():
-    pth_dose_rate = "data_test/prostate-glen-p1-dose/scaled_run_1.nrrd"
-    dose_rate_dict = _load_single_dose_or_uncertainty_to_dict(pth_dose_rate, "both")
-    print(dose_rate_dict[0].shape)  # dose
-    print(dose_rate_dict[1].shape)  # uncertainty
-
 def test_export_brachy_plan():
     pth_dicom = Path("data_test/prostate-glen-p1-dcm").resolve()
     dir_export = Path("data_test/test_export_plan/prostate").resolve()
@@ -338,7 +331,16 @@ def test_load_phantom():
     plan_obj = BrachyPlan(phantom=pth_dicom, dvh_metric_goals=dvh_metric_goals)
     plan_obj.info()
 
-
+def test_run_dose_generation():
+    pth_dicom = Path("data_test/prostate-glen-p1-dcm").resolve()
+    # dir_export = Path("data_test/test_export_plan/prostate").resolve()
+    plan_obj = get_a_plan(
+        pth_dicom=pth_dicom,
+    )
+    # test the case with only combined dose
+    # XXX pick up here!
+    plan_obj.run_dose_generation()
+    print("debug here")
 if __name__ == "__main__":
     # testupdate_plan_from_catheter_table()
     # test_update_catheter_table_from_plan()
@@ -348,9 +350,10 @@ if __name__ == "__main__":
     # test_calculate_uncertainty_per_structure()
     # test_BrachyPlan()
     # test__load_single_dose_or_uncertainty_to_dict()
-    test_export_brachy_plan()
+    # test_export_brachy_plan()
     # test_load_brachy_plan_from_dicom()
     # test_load_applicator_list()
     # test__export_applicator_geometry()
     # test_brachy_structure()
     # test_load_phantom()
+    test_run_dose_generation()

--- a/brachyutils/tests/test_plan_utils.py
+++ b/brachyutils/tests/test_plan_utils.py
@@ -331,15 +331,6 @@ def test_load_phantom():
     plan_obj = BrachyPlan(phantom=pth_dicom, dvh_metric_goals=dvh_metric_goals)
     plan_obj.info()
 
-def test_run_dose_generation():
-    pth_dicom = Path("data_test/prostate-glen-p1-dcm").resolve()
-    # dir_export = Path("data_test/test_export_plan/prostate").resolve()
-    plan_obj = get_a_plan(
-        pth_dicom=pth_dicom,
-    )
-    # test the case with only combined dose
-    plan_obj.run_dose_generation()
-    print("debug here")
 if __name__ == "__main__":
     # testupdate_plan_from_catheter_table()
     # test_update_catheter_table_from_plan()
@@ -347,7 +338,7 @@ if __name__ == "__main__":
     # test_create_structures_and_calc_dvh_metrics()
     # test_calculate_combined_uncertainty()
     # test_calculate_uncertainty_per_structure()
-    # test_BrachyPlan()
+    test_BrachyPlan()
     # test__load_single_dose_or_uncertainty_to_dict()
     # test_export_brachy_plan()
     # test_load_brachy_plan_from_dicom()
@@ -355,4 +346,3 @@ if __name__ == "__main__":
     # test__export_applicator_geometry()
     # test_brachy_structure()
     # test_load_phantom()
-    test_run_dose_generation()

--- a/examples/WGDCAB_test_cases/water_phantom/setup_tg186_sims.py
+++ b/examples/WGDCAB_test_cases/water_phantom/setup_tg186_sims.py
@@ -93,7 +93,7 @@ def fix_source_orientation_for(i, catheter_table):
     elif(i == 4):
         rotation = [0, 0, 1]
 
-    catheter_table.catheter_list[0].dwells[0].rotation = rotation
+    catheter_table.catheters_list[0].dwells[0].rotation = rotation
 ####################################
 def create_material_dict_for(i):
     material_dict = {}

--- a/examples/benchmarks/eval_optim.py
+++ b/examples/benchmarks/eval_optim.py
@@ -98,7 +98,7 @@ def get_a_plan_to_optimize(
             dir_dose_rates/"dose_rate_generation_timing.csv",
             index=False,
         )
-    plan_obj.load_dose_rate_dict(
+    plan_obj.load_dose_rates(
         dir_dose_rate=dir_dose_rates,
         multi_processing=True,
     )

--- a/examples/minimal_sim.py
+++ b/examples/minimal_sim.py
@@ -8,7 +8,7 @@ def export_plan_air_phantom():
     """
     dir_export = "data_test/test_export_plan/prostate"
     catheterTable = CatheterTable(
-        catheter_list=[
+        catheters_dict=[
             Catheter(
                 index=0,
                 dwells=[


### PR DESCRIPTION
- You can treat catheter table as both a list and a dictionary since you can get the catheters by providing index, slice as well as key string. note that the key string (name_id) is defined as index +1.
- The dose rates and combined dose are now property of the catheter table. Each dwell position comes with its own dose rate. This allows for dynamic dose generation.
- Many computed fields were added to the catheter table, while providing caching to save compute.