### PR TITLE
Plan no dvh dict

### DIFF
--- a/brachyutils/geometry/catheter_utils/catheter_table.py
+++ b/brachyutils/geometry/catheter_utils/catheter_table.py
@@ -949,7 +949,7 @@ in the catheters_dict. there is a big bug somewhere in catheter table creation")
         ### Outputs:
         - None: will set self._cached_combined_dose
         """
-        if isinstance(self.combined_dose, Path) or isinstance(self.combined_dose, str):
+        if isinstance(combined_dose, Path) or isinstance(combined_dose, str):
             combined_dose = BrachyDose(pth_dose_file=combined_dose) 
         self._cached_combined_dose = combined_dose
 

--- a/brachyutils/geometry/catheter_utils/catheter_table.py
+++ b/brachyutils/geometry/catheter_utils/catheter_table.py
@@ -663,8 +663,8 @@ class CatheterTable(BaseModel):
         dwells_with_doserate = [dwell for dwell in all_dwells if dwell.dose_rate is not None]
         
         if not dwells_with_doserate:
-            # return self._cached_combined_dose
-            raise ValueError("No dose rate found in this catheter table")
+            return self._cached_combined_dose
+            # raise ValueError("No dose rate found in this catheter table")
 
         # Initialize combined dose if not cached
         if self._cached_combined_dose is None:
@@ -938,6 +938,20 @@ in the catheters_dict. there is a big bug somewhere in catheter table creation")
             catheters_dict=dict_catheter_diffs,
             from_delivered_dwellpositions=self.from_delivered_dwellpositions
         )
+
+    def set_combined_dose(self, combined_dose: BrachyDose | Path | str):
+        r"""
+        ### Purpose:
+        To set the combined dose without the dose rates.
+        ### Inputs:
+        - combined_dose : BrachyDose | Path | str: The combined dose corresponding to this catheter table.
+        If a string or Path is provided, we will load it from a file.
+        ### Outputs:
+        - None: will set self._cached_combined_dose
+        """
+        if isinstance(self.combined_dose, Path) or isinstance(self.combined_dose, str):
+            combined_dose = BrachyDose(pth_dose_file=combined_dose) 
+        self._cached_combined_dose = combined_dose
 
     def append(self, catheter: Catheter) -> None:
         r"""

--- a/brachyutils/geometry/phantom_utils.py
+++ b/brachyutils/geometry/phantom_utils.py
@@ -1838,7 +1838,7 @@ def mask_to_stl(roi_mask: ROIMask, pth_output: Path) -> None:
     Outputs:
         - None
     """
-
+    import vtk
     # Note: Implementation is cannablized from PolySeg (https://github.com/PerkLab/PolySeg/)
     if not isinstance(roi_mask, ROIMask):
         raise ValueError("The input roi_mask should be an instance of ROIMask.")

--- a/brachyutils/planning/plan_utils.py
+++ b/brachyutils/planning/plan_utils.py
@@ -277,7 +277,6 @@ class BrachyPlan:
         # phantom and geometry attributes
         self.phantom: BrachyPhantom = None
         self.dvh_metric_goals: dict = None
-        self.dvh_metrics_observed: dict = None
         self.structure_list: List[BrachyStructure] = []
         self.body_contour: ROIContour = None
         self.phantom_origin: list = None  # np.array([0, 0, 0])  # x,y,z
@@ -901,7 +900,7 @@ class BrachyPlan:
         combined_dose: BrachyDose=None,
         prescription_dose: float = None,
         return_percentage: bool = True,
-        ):
+        ) -> dict:
         r"""
         ### Purpose:
         - To get the observed value of the dvh metric for each structure in the BrachyPlan.
@@ -909,15 +908,16 @@ class BrachyPlan:
         ### Inputs:
         - self := the BrachyPlan object
         ### Outputs:
-        - Void := will update the BrachyStructure.dvh_metrics_observed attribute
+        - dvh_metrics_observed: a dictionary mapping every DVH metric to its observed value.
         """
         assert self.structure_list is not None, "structure list is not created yet"
         assert self.prescription_dose is not None, "prescription dose is not set"
+        assert self.dvh_metric_goals is not None, "DVH metrics are not set, please run set_dvh_metric_goals()"
         if combined_dose is None:
             combined_dose = self.combined_dose
         if prescription_dose is None:
             prescription_dose = self.prescription_dose
-        self.dvh_metrics_observed = {}
+        dvh_metrics_observed = {}
         for structure_obj in self.structure_list:
             if "hotspot_estimator" in structure_obj.name.lower():
                 continue
@@ -927,8 +927,8 @@ class BrachyPlan:
                 return_percentage,
                 self.body_contour,
                 )
-            self.dvh_metrics_observed.update(observed_metrics)
-        return self.dvh_metrics_observed
+            dvh_metrics_observed.update(observed_metrics)
+        return dvh_metrics_observed
 
     def export_dvh_metrics(self, output_pth: Union[str, Path]):
         r"""

--- a/brachyutils/planning/plan_utils.py
+++ b/brachyutils/planning/plan_utils.py
@@ -208,7 +208,6 @@ class BrachyPlan:
         #### for geometry definition:
         phantom: Union[Path, BrachyPhantom, dict] = None,
         #### for structure creation:
-        # dvh_metric_goals: Union[dict, Path] = None,
         prescription_dose: float = None,
         strict_name_match: bool = True,
         #### for loading catheter table and/or applicators:
@@ -263,7 +262,9 @@ class BrachyPlan:
         - applicator_format:str = "RapidBrachy" := the format of the applicator list 
         (default is "RapidBrachy"). See load_applicator_list() for more info. 
         - load_uncertainty: bool := If true, it will the uncertainty of the dose rates as well.
-        - dvh_metric_goals:dict|Path := Dictionary containing the DVH metric goals or the path to its json file. Look at BrachyStructure for more info.
+        - dvh_metric_goals: List[str] | Dict[str, float] | Path | str := A list of all DVH metric
+        names or the dictionary containing the DVH metric names and their goals or the path to its
+        json file. Look at set_dvh_metric_goals for guideline on the names of the DVH metrics.
         The phantom should be loaded with structures for the Brachy stuctures to be created.
 
         ### Outputs:
@@ -324,14 +325,25 @@ class BrachyPlan:
         if self.phantom is not None:
             self.set_brachy_structure_list(
                 phantom=self.phantom,
-                dvh_metric_goals=self.dvh_metric_goals,
                 strict_name_match=strict_name_match,
             )
 
         if kwargs.get("dvh_metric_goals", None) is not None:
+            dvh_metric_goals = kwargs.get("dvh_metric_goals")
             if self.prescription_dose is None:
                 raise ValueError("prescription dose is not provided. Please provide it.")
-            self.set_dvh_metric_goals(kwargs.get("dvh_metric_goals"))
+            if isinstance(dvh_metric_goals, str) or isinstance(dvh_metric_goals, Path):
+                dvh_metric_goals = Path(dvh_metric_goals)
+                with open(dvh_metric_goals, "r") as json_file:
+                    dvh_metric_goals = json.load(json_file)
+            if isinstance(dvh_metric_goals, list):
+                self.set_dvh_metric_goals(
+                    dvh_metric_names=dvh_metric_goals,
+                    strict_name_match=strict_name_match)
+            elif isinstance(dvh_metric_goals, dict):
+                self.set_dvh_metric_goals(
+                    dvh_metric_goals=dvh_metric_goals,
+                    strict_name_match=strict_name_match)
 
         # load the catheter table if the path is provided
         if catheter_table is not None:
@@ -601,8 +613,8 @@ class BrachyPlan:
 
     def set_dvh_metric_goals(
         self,
-        dvh_metric_names: List[str]=None,
-        dvh_metric_goals: Union[dict, Path]=None,
+        dvh_metric_names: List[str] | Path = None,
+        dvh_metric_goals: dict | Path = None,
         strict_name_match: bool = True
         ) -> None:
         r"""
@@ -634,6 +646,10 @@ class BrachyPlan:
 
         if len(self.structure_list) == 0:
             raise ValueError("The plan structure set is empty, please run set_brachy_structure_list")
+
+        if isinstance(dvh_metric_names, Path):
+            with open(dvh_metric_names, "r") as json_file:
+                dvh_metric_names = json.load(json_file)
 
         if dvh_metric_goals is not None:
             if isinstance(dvh_metric_goals, Path):

--- a/brachyutils/planning/plan_utils.py
+++ b/brachyutils/planning/plan_utils.py
@@ -921,6 +921,8 @@ class BrachyPlan:
         for structure_obj in self.structure_list:
             if "hotspot_estimator" in structure_obj.name.lower():
                 continue
+            if not any(structure_obj.dvh_metric_names):
+                continue
             observed_metrics = structure_obj.get_dvh_metric(
                 combined_dose,
                 prescription_dose,

--- a/brachyutils/planning/plan_utils.py
+++ b/brachyutils/planning/plan_utils.py
@@ -325,7 +325,6 @@ class BrachyPlan:
         if self.phantom is not None:
             self.set_brachy_structure_list(
                 phantom=self.phantom,
-                strict_name_match=strict_name_match,
             )
 
         if kwargs.get("dvh_metric_goals", None) is not None:

--- a/brachyutils/planning/plan_utils.py
+++ b/brachyutils/planning/plan_utils.py
@@ -208,7 +208,7 @@ class BrachyPlan:
         #### for geometry definition:
         phantom: Union[Path, BrachyPhantom, dict] = None,
         #### for structure creation:
-        dvh_metric_goals: Union[dict, Path] = None,
+        # dvh_metric_goals: Union[dict, Path] = None,
         prescription_dose: float = None,
         strict_name_match: bool = True,
         #### for loading catheter table and/or applicators:
@@ -233,8 +233,6 @@ class BrachyPlan:
         or a dictionary containing the paths. A phantom object can include structures as well. See load_phantom() for more info.
 
         #### For Structure optimization and dosimetry
-        - dvh_metric_goals:dict|Path := Dictionary containing the DVH metric goals or the path to its json file. Look at BrachyStructure for more info.
-        The phantom should be loaded with structures for the Brachy stuctures to be created.
         - prescription_dose: float = None := The dose that is prescribed to the target volume. This is used to calculate the DVH metrics. 
 
         #### for loading catheter table and applicators:
@@ -244,6 +242,14 @@ class BrachyPlan:
         #### for loading dose rates or uncertainty maps per dwell position:
         - combined_dose: Path|BrachyDose := the path to the combined dose file or a BrachyDose object.
         - dir_dose_rate:str := path to the directory containing the dose rate files for a patient.
+
+        #### for simulation setup:
+        - simulation_setup = None := dictionary containing the simulation setup,
+        - load_uncertainty:bool := If True, the uncertainties of the dose rates are also loaded. 
+        - multi_processing:bool :=  If True, 16 threads are used to load the dose rates simulatenously.
+        - combined_dose_only:bool := If True, all the dose rates will be removed from memory after 
+        combined dose is calculated.
+        - dose_dtype:np.float32 := The floating point type to store the dose rates. 
 
         #### Keywords Arguments:
         - from_delivered_dwellpositions: bool = True := if True, will only load the dwell positions that
@@ -256,14 +262,10 @@ class BrachyPlan:
         - one_hotspot_structure: bool: = True := if False, will create separate hotspot structures
         - applicator_format:str = "RapidBrachy" := the format of the applicator list 
         (default is "RapidBrachy"). See load_applicator_list() for more info. 
-        - load_uncertainty: bool := If true, it will the uncertainty of the dose rates as well. 
-        #### for simulation setup:
-        - simulation_setup = None := dictionary containing the simulation setup,
-        - load_uncertainty:bool := If True, the uncertainties of the dose rates are also loaded. 
-        - multi_processing:bool :=  If True, 16 threads are used to load the dose rates simulatenously.
-        - combined_dose_only:bool := If True, all the dose rates will be removed from memory after 
-        combined dose is calculated.
-        - dose_dtype:np.float32 := The floating point type to store the dose rates. 
+        - load_uncertainty: bool := If true, it will the uncertainty of the dose rates as well.
+        - dvh_metric_goals:dict|Path := Dictionary containing the DVH metric goals or the path to its json file. Look at BrachyStructure for more info.
+        The phantom should be loaded with structures for the Brachy stuctures to be created.
+
         ### Outputs:
             - Void := will initialize the BrachyPlan object
         """
@@ -297,8 +299,8 @@ class BrachyPlan:
         self.applicator_rotation_origin: float = np.array([0, 0, 0])  # x,y,z
 
         # dose attributes
-        self.dose_rate_dict = defaultdict(BrachyDose)
-        # self.combined_dose: BrachyDose = None
+        # self.dose_rate_dict = defaultdict(BrachyDose) XXX
+        # self.combined_dose: BrachyDose = None XXX
 
         # simulation attributes
         self.simulation_setup: BrachySimulation = None
@@ -306,10 +308,10 @@ class BrachyPlan:
         ## fill the attributes depending on the inputs to the constructor
         # set the dvh metric goals if provided
         self.prescription_dose = prescription_dose
-        if dvh_metric_goals is not None:
+        if kwargs.get("dvh_metric_goals", None) is not None:
             if self.prescription_dose is None:
                 raise ValueError("prescription dose is not provided. Please provide it.")
-            self.set_dvh_metric_goals(dvh_metric_goals)
+            self.set_dvh_metric_goals(kwargs.get("dvh_metric_goals"))
 
         # load the dicom plan if the path is provided
         if phantom is not None:
@@ -324,7 +326,7 @@ class BrachyPlan:
             else:
                 raise ValueError("phantom should be a BrachyPhantom object or a path")
         # create structures based on the phantom structures and DVH metric goals
-        if self.phantom is not None and self.dvh_metric_goals is not None:
+        if self.phantom is not None:
             self.create_brachy_structure_set(
                 phantom=self.phantom,
                 dvh_metric_goals=self.dvh_metric_goals,
@@ -535,7 +537,7 @@ class BrachyPlan:
                         margin_mm=5.0,
                     )
         self.update_plan_from_catheter_table(
-            time_diffs=time_diffs if 'time_diffs' in locals() else None)
+            time_diffs=self.catheter_table._time_diffs)
 
     def update_plan_from_catheter_table(self, time_diffs=None):
         r"""
@@ -614,10 +616,10 @@ class BrachyPlan:
     def create_brachy_structure_set(
         self,
         phantom: BrachyPhantom,
-        dvh_metric_goals: dict,
+        dvh_metric_goals: dict = None,
         mask_type: Union[ROIContour, ROIMask] = ROIContour,
         strict_name_match: bool = True,
-    ):
+        ):
         r"""
         ### Purpose:
         - To create a list of BrachyStructure objects from the structures in the phantom and
@@ -632,18 +634,23 @@ class BrachyPlan:
         - BrachyDicom
         """
         self.structure_list = []
-        structure_names_in_dvh = list(set([ #list of the structure names
-            x.split("(")[-1].split(")")[0] for x in dvh_metric_goals.keys()
-        ]))
-        #separate dvh metric goals into separate dictionaries by structure
         dvh_metric_goals_by_structure = {}
-        for structure_name in structure_names_in_dvh:
-            dvh_metric_goals_per_struct = {
-                key: value
-                for key, value in dvh_metric_goals.items()
-                if structure_name in key
-            }
-            dvh_metric_goals_by_structure[structure_name] = dvh_metric_goals_per_struct
+
+        if dvh_metric_goals is None:
+            structure_names_in_dvh = self.phantom.structure_names
+        else:
+            structure_names_in_dvh = list(set([ #list of the structure names
+                x.split("(")[-1].split(")")[0] for x in dvh_metric_goals.keys()
+            ]))
+        #separate dvh metric goals into separate dictionaries by structure
+            for structure_name in structure_names_in_dvh:
+                dvh_metric_goals_per_struct = {
+                    key: value
+                    for key, value in dvh_metric_goals.items()
+                    if structure_name in key
+                }
+                dvh_metric_goals_by_structure[structure_name] = dvh_metric_goals_per_struct
+
         if phantom.cached_structure_masks is not None:
             structure_masks = deepcopy(phantom.cached_structure_masks)
             for k in list(structure_masks.keys()):
@@ -661,8 +668,11 @@ class BrachyPlan:
                 is_target=True if (
                     "ctv" in structure_name.lower()
                     or "ptv" in structure_name.lower())  else False,
-                in_dvh=True,
-                dvh_metric_goals=dvh_metric_goals_by_structure[structure_name],
+                # in_dvh=True,
+                dvh_metric_goals=(
+                    dvh_metric_goals_by_structure.get(structure_name, None)
+                    if any(dvh_metric_goals_by_structure)
+                    else None),
             )
             self.structure_list.append(structure_obj)
         if phantom.cached_structure_masks is not None:

--- a/brachyutils/planning/plan_utils.py
+++ b/brachyutils/planning/plan_utils.py
@@ -300,8 +300,6 @@ class BrachyPlan:
         self.applicator_rotation_origin: float = np.array([0, 0, 0])  # x,y,z
 
         # dose attributes
-        # self.dose_rate_dict = defaultdict(BrachyDose) XXX
-        # self.combined_dose: BrachyDose = None XXX
 
         # simulation attributes
         self.simulation_setup: BrachySimulation = None
@@ -352,7 +350,6 @@ class BrachyPlan:
                 dwells_near_ptv=kwargs.get("dwells_near_ptv", True),
                 )
         # load the dose rate dict if the path is provided
-        # XXX Continue debugging from here
         if dir_dose_rate is not None and combined_dose is None:
             self.catheter_table.load_dose_rates(
                 dir_dose_rate=dir_dose_rate,
@@ -361,13 +358,8 @@ class BrachyPlan:
                 combined_dose_only=kwargs.get("combined_dose_only", False),
                 dose_dtype=kwargs.get("dose_dtype", np.float32),
                 )
-            self.combined_dose = self.catheter_table.combined_dose
-
         elif dir_dose_rate is None and combined_dose is not None:
-            if isinstance(combined_dose, BrachyDose):
-                self.combined_dose = combined_dose
-            elif isinstance(combined_dose, Path) or isinstance(combined_dose, str):
-                self.combined_dose = BrachyDose(Path(combined_dose))
+            self.catheter_table.set_combined_dose(combined_dose)
         elif dir_dose_rate is not None and combined_dose is not None:
             raise ValueError(
                 "invalid input. Please provide either dir_dose_rate or combined_dose but not both"
@@ -607,8 +599,6 @@ class BrachyPlan:
                 len(self.dwell_numbers) == self.dwell_numbers[-1]
             ), "dwell numbers are not extracted correctly"
             self.num_dwells = len(self.dwell_numbers)
-        if any(self.dose_rate_dict):
-            self._calculate_combined_dose(time_diffs=time_diffs)
 
     def set_dvh_metric_goals(
         self,
@@ -1634,6 +1624,7 @@ config do not match for structure {struc.name}"
         TODO: get rid of +1 when moving towards catheter generation from digi points
         TODO: Consider adding angle to the name later when IMBT is involved.
         """
+        raise DeprecationWarning("This function need to be adapted to the new catheter table")
         if len(self.dose_rate_dict) == 0:
             raise ValueError("dose rate maps are not generated yet. run dose generation first")
         dose_rates_catheter = defaultdict(BrachyDose)

--- a/brachyutils/planning/plan_utils.py
+++ b/brachyutils/planning/plan_utils.py
@@ -308,11 +308,6 @@ class BrachyPlan:
         ## fill the attributes depending on the inputs to the constructor
         # set the dvh metric goals if provided
         self.prescription_dose = prescription_dose
-        if kwargs.get("dvh_metric_goals", None) is not None:
-            if self.prescription_dose is None:
-                raise ValueError("prescription dose is not provided. Please provide it.")
-            self.set_dvh_metric_goals(kwargs.get("dvh_metric_goals"))
-
         # load the dicom plan if the path is provided
         if phantom is not None:
             if isinstance(phantom, BrachyPhantom):
@@ -327,11 +322,17 @@ class BrachyPlan:
                 raise ValueError("phantom should be a BrachyPhantom object or a path")
         # create structures based on the phantom structures and DVH metric goals
         if self.phantom is not None:
-            self.create_brachy_structure_set(
+            self.set_brachy_structure_list(
                 phantom=self.phantom,
                 dvh_metric_goals=self.dvh_metric_goals,
                 strict_name_match=strict_name_match,
             )
+
+        if kwargs.get("dvh_metric_goals", None) is not None:
+            if self.prescription_dose is None:
+                raise ValueError("prescription dose is not provided. Please provide it.")
+            self.set_dvh_metric_goals(kwargs.get("dvh_metric_goals"))
+
         # load the catheter table if the path is provided
         if catheter_table is not None:
             self.set_catheter_table(
@@ -598,44 +599,51 @@ class BrachyPlan:
         if any(self.dose_rate_dict):
             self._calculate_combined_dose(time_diffs=time_diffs)
 
-    def set_dvh_metric_goals(self, dvh_metric_goals: Union[dict, Path]):
-        r"""
-        ### Purpose:
-        - To set the dvh metric list of the BrachyPlan object.
-        ### Inputs:
-        - dvh_metric_goals := a list of dictionaries. each dictionary contains the keys:
-        "structure_name", "clinical_goal", "observed_value", and "penalty_weight"
-        ### Outputs:
-            - Void := will update the BrachyPlan.dvh_metric_goals attribute
-        """
-        if isinstance(dvh_metric_goals, Path):
-            with open(dvh_metric_goals, "r") as json_file:
-                dvh_metric_goals = json.load(json_file)
-        self.dvh_metric_goals = dvh_metric_goals
-
-    def create_brachy_structure_set(
+    def set_dvh_metric_goals(
         self,
-        phantom: BrachyPhantom,
-        dvh_metric_goals: dict = None,
-        mask_type: Union[ROIContour, ROIMask] = ROIContour,
-        strict_name_match: bool = True,
-        ):
+        dvh_metric_names: List[str]=None,
+        dvh_metric_goals: Union[dict, Path]=None,
+        strict_name_match: bool = True
+        ) -> None:
         r"""
         ### Purpose:
-        - To create a list of BrachyStructure objects from the structures in the phantom and
-        the DVH metric goals. Each BrachyStructure object will have attributes for the structure
-        contour, the DVH and uncertainty volume histograms, optimization attributes, and simulation attributes.
-        ### Inputes:
-        - self.phantom := the phantom with its structures fully loaded.
-        - self.dvh_metric_goals := the dvh metric goals dictionary
+        - To set the dvh metric list of the BrachyPlan object and each of the BrachyStructures.
+        You can provide either the dvh_metric_names or the dvh_metric_goals.
+        ### Inputs:
+        - dvh_metric_names: List[str] := a list containing the DVH metrics for this structure. The names 
+        are of the format V_{#Gy|%}(organName), where # represents the numerical threshold and "|" is or.
+        For example D95%(organName).
+        - dvh_metric_goals:Dict[str, float] := a dictionary of DVH metrics and their clinical goals.
+        The keys should be following the same convention as for dvh_metric_names.
+        - strict_name_match: bool := If True, the name of the structure in the phantom and the DVH metric
+        goals should mask perfectly. Otherwise, the name of the structure in the DVH metric goals can be
+        a substring of the name of the structure in the phantom. For example, "CTV" vs "CTV_BRACHY".
         ### Outputs:
-        - Void := will update the BrachyPlan.structure_list attribute
-        ### Dependencies:
-        - BrachyDicom
+        - None := will update the BrachyPlan.dvh_metric_goals attribute
         """
-        self.structure_list = []
-        dvh_metric_goals_by_structure = {}
+        if dvh_metric_names is not None and dvh_metric_goals is not None:
+            raise ValueError("Please provide either dvh_metric_names or dvh_metric_goals, not both") 
 
+        if len(self.structure_list) == 0:
+            raise ValueError("The plan structure set is empty, please run set_brachy_structure_list")
+
+        if dvh_metric_goals is not None:
+            if isinstance(dvh_metric_goals, Path):
+                with open(dvh_metric_goals, "r") as json_file:
+                    dvh_metric_goals = json.load(json_file)
+            dvh_metric_names = list(dvh_metric_goals.keys())
+
+        self.dvh_metric_goals = {}
+        # let's match the structure names in the DVH with the structure names
+        # in the BrachyPlan.
+        for brachy_structure in self.structure_list:
+            XXX
+            if strict_name_match:
+                for dvh_name in dvh_metric_names:
+                    structure_name_in_dvh = dvh_name.split("(")[-1].split(")")[0]
+                    relevant_dvh_metrics = 
+
+        dvh_metric_goals_by_structure = {}
         if dvh_metric_goals is None:
             structure_names_in_dvh = self.phantom.structure_names
         else:
@@ -651,14 +659,30 @@ class BrachyPlan:
                 }
                 dvh_metric_goals_by_structure[structure_name] = dvh_metric_goals_per_struct
 
+    def set_brachy_structure_list(
+        self,
+        phantom: BrachyPhantom,
+        mask_type: Union[ROIContour, ROIMask] = ROIContour,
+        )->None:
+        r"""
+        ### Purpose:
+        - To create a list of BrachyStructure objects from the structures in the phantom and
+        the DVH metric goals. Each BrachyStructure object will have attributes for the structure
+        contour, the DVH and uncertainty volume histograms, optimization attributes, and simulation attributes.
+        ### Inputes:
+        - phantom := the phantom with its structures fully loaded.
+        - dvh_metric_goals := the dvh metric goals dictionary
+        - mask_type: ROIContour | ROIMask := Phantom masks will be converted to this type when being
+        stored in BrachySturucture.
+        ### Outputs:
+        - None := will update the BrachyPlan.structure_list attribute
+        """
+        self.structure_list = []
         if phantom.cached_structure_masks is not None:
             structure_masks = deepcopy(phantom.cached_structure_masks)
-            for k in list(structure_masks.keys()):
-                if k not in structure_names_in_dvh:
-                    structure_masks.pop(k)
         else:
             structure_masks: dict = phantom.get_structure_mask(
-                structure_names_in_dvh, mask_type, strict_name_match=strict_name_match
+                phantom.structure_names, mask_type,
             )
 
         for structure_name in structure_masks.keys():
@@ -668,11 +692,6 @@ class BrachyPlan:
                 is_target=True if (
                     "ctv" in structure_name.lower()
                     or "ptv" in structure_name.lower())  else False,
-                # in_dvh=True,
-                dvh_metric_goals=(
-                    dvh_metric_goals_by_structure.get(structure_name, None)
-                    if any(dvh_metric_goals_by_structure)
-                    else None),
             )
             self.structure_list.append(structure_obj)
         if phantom.cached_structure_masks is not None:

--- a/brachyutils/planning/plan_utils.py
+++ b/brachyutils/planning/plan_utils.py
@@ -619,7 +619,15 @@ class BrachyPlan:
         goals should mask perfectly. Otherwise, the name of the structure in the DVH metric goals can be
         a substring of the name of the structure in the phantom. For example, "CTV" vs "CTV_BRACHY".
         ### Outputs:
-        - None := will update the BrachyPlan.dvh_metric_goals attribute
+        - None := will update the BrachyPlan.dvh_metric_goals attribute as well as 
+        BrachyStructure.dvh_metric_names and BrachyStructure.dvh_metric_goals.
+        The keys of the BrachyPlan.dvh_metric_goals are:
+        {
+            BrachyStructure.name: {
+                "dvh_metric_names: [list of the names for that structure],
+                "dvh_metric_goals: {if applicable}
+            }    
+        }
         """
         if dvh_metric_names is not None and dvh_metric_goals is not None:
             raise ValueError("Please provide either dvh_metric_names or dvh_metric_goals, not both") 
@@ -633,31 +641,42 @@ class BrachyPlan:
                     dvh_metric_goals = json.load(json_file)
             dvh_metric_names = list(dvh_metric_goals.keys())
 
-        self.dvh_metric_goals = {}
+        self.dvh_metric_goals = defaultdict(dict)
         # let's match the structure names in the DVH with the structure names
         # in the BrachyPlan.
         for brachy_structure in self.structure_list:
-            XXX
-            if strict_name_match:
-                for dvh_name in dvh_metric_names:
-                    structure_name_in_dvh = dvh_name.split("(")[-1].split(")")[0]
-                    relevant_dvh_metrics = 
-
-        dvh_metric_goals_by_structure = {}
-        if dvh_metric_goals is None:
-            structure_names_in_dvh = self.phantom.structure_names
-        else:
-            structure_names_in_dvh = list(set([ #list of the structure names
-                x.split("(")[-1].split(")")[0] for x in dvh_metric_goals.keys()
-            ]))
-        #separate dvh metric goals into separate dictionaries by structure
-            for structure_name in structure_names_in_dvh:
-                dvh_metric_goals_per_struct = {
-                    key: value
-                    for key, value in dvh_metric_goals.items()
-                    if structure_name in key
-                }
-                dvh_metric_goals_by_structure[structure_name] = dvh_metric_goals_per_struct
+            # get all the dvh metrics for this structure
+            structure_dvh_metrics_names = []
+            for dvh_name in dvh_metric_names:
+                structure_name_in_dvh = dvh_name.split("(")[-1].split(")")[0]
+                if strict_name_match:
+                    if brachy_structure.name == structure_name_in_dvh:
+                        structure_dvh_metrics_names.append(dvh_name)
+                    else:
+                        continue
+                else:
+                    if brachy_structure.name in structure_name_in_dvh:
+                        structure_dvh_metrics_names.append(dvh_name)
+                    else:
+                        continue
+            self.dvh_metric_goals[brachy_structure.name] = {
+                "dvh_metric_names": structure_dvh_metrics_names
+            }
+            brachy_structure.set_dvh_metric_names(
+                self.dvh_metric_goals.get(brachy_structure.name).get("dvh_metric_names")
+            )
+            if dvh_metric_goals is not None:
+                self.dvh_metric_goals[brachy_structure.name] = {
+                        "dvh_metric_goals": {}}
+                for dvh_name in structure_dvh_metrics_names:
+                    self.dvh_metric_goals[brachy_structure.name] = {
+                        "dvh_metric_goals": {
+                            dvh_name: dvh_metric_goals[dvh_name]
+                        }
+                    }
+                brachy_structure.set_dvh_metric_goals(
+                    self.dvh_metric_goals.get(brachy_structure.name).get("dvh_metric_goals")
+                )
 
     def set_brachy_structure_list(
         self,

--- a/brachyutils/planning/plan_utils.py
+++ b/brachyutils/planning/plan_utils.py
@@ -618,7 +618,7 @@ class BrachyPlan:
         The keys should be following the same convention as for dvh_metric_names.
         - strict_name_match: bool := If True, the name of the structure in the phantom and the DVH metric
         goals should mask perfectly. Otherwise, the name of the structure in the DVH metric goals can be
-        a substring of the name of the structure in the phantom. For example, "CTV" vs "CTV_BRACHY".
+        a substring of the name of the structure in the phantom. For example, "CTV" in "CTV_BRACHY".
         ### Outputs:
         - None := will update the BrachyPlan.dvh_metric_goals attribute as well as 
         BrachyStructure.dvh_metric_names and BrachyStructure.dvh_metric_goals.
@@ -660,7 +660,7 @@ class BrachyPlan:
                     else:
                         continue
                 else:
-                    if brachy_structure.name in structure_name_in_dvh:
+                    if structure_name_in_dvh in brachy_structure.name:
                         structure_dvh_metrics_names.append(dvh_name)
                     else:
                         continue

--- a/brachyutils/planning/structure_utils.py
+++ b/brachyutils/planning/structure_utils.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict
+from typing import Any, Dict, List
 from opentps.core.data.images import ROIMask
 from opentps.core.data import DVH, ROIContour
 import numpy as np
@@ -18,6 +18,7 @@ class BrachyStructure:
     - mask: ROIMask
     - is_target: bool
     #### DVH Attributes:
+    - dvh_metric_names
     - in_dvh: bool
     - dvh_metric_goals: Dict[str, float]
     - dvh_metrics_observed: Dict[str, float]
@@ -37,13 +38,13 @@ class BrachyStructure:
 
     def __init__(
         self,
-        name: str = None,
-        mask: ROIMask | ROIContour = None,
-        is_target: bool = None,
+        name: str,
+        dvh_metric_names: List[str],
+        mask: ROIMask | ROIContour,
+        is_target: bool = False,
         in_dvh: bool = True,
-        dvh_metric_goals: Dict[str, float] = None,
         optimization_config: Optimization_Config = None,
-    ) -> None:
+        ) -> None:
         r"""
         ### Purpose:
         - To initialize the BrachyStructure object.
@@ -52,8 +53,10 @@ class BrachyStructure:
         - mask:ROIMask | ROIContour := the mask or contour of the structure.
         - is_target:bool := flag to indicate whether the structure is a target volume or not.
         - in_dvh:bool := flag to indicate whether the structure is included in the dose volume histogram.
+        - dvh_metric_names: List[str] := a list containing the DVH metrics for this structure. The names 
+        are of the format V_{#Gy|%}(organName), where # represents the numerical threshold and "|" is or.
+        For example D95%(organName).
         - dvh_metric_goals:Dict[str, float] := a dictionary of DVH metrics and their clinical goals.
-        V_{#Gy|%}(organName), where # represents the numerical threshold and "|" is or. For example D95%(organName).
         - optimization_config:Optimization_Config := the optimization config object for the structure. see optim_utils.py 
         ### Outputs:
         - Void := will initialize the BrachyStructure object
@@ -67,6 +70,7 @@ class BrachyStructure:
 
         # dose volume histogram
         self.in_dvh:bool = in_dvh
+        self.dvh_metric_names: List[str] = None
         self.dvh_metric_goals: Dict[str, float] = None
         self.dvh_metrics_observed: Dict[str, float] = None
         self.dvh_obj: DVH = None
@@ -82,16 +86,26 @@ class BrachyStructure:
         self.optimization_config: Optimization_Config = None
         # self.optimization_mask: ROIMask = None
 
-        if self.in_dvh: # XXX figure out how to do this only optionally!
-            if dvh_metric_goals is None:
-                raise ValueError(
-                    """Please provide BrachyStructure with a dictionary of multiple metrics and goals"""
-                    )
-            self.dvh_metric_goals = dvh_metric_goals
-            assert np.all([self.name.lower() in dvh_metric_name.lower() for dvh_metric_name in self.dvh_metric_goals.keys()]),\
-             "name should be in dvh metric name enclosed by paranthesis"
+        assert np.all(
+            [self.name.lower() in dvh_metric_name.lower()
+            for dvh_metric_name in dvh_metric_names]),\
+            "name should be in dvh metric name enclosed by paranthesis"
+        self.dvh_metric_names = dvh_metric_names
+
         if optimization_config is not None:
             self.set_optimization_config(optimization_config)
+
+    def set_dvh_metric_goals(self, dvh_metric_goals: List[str] | Dict[str, float]):
+        r"""
+        ### Purpose:
+        - To set the DVH metrics or their goals for this structure.
+        If a list of strings is provided, then we only set the metrics.
+        If a dictionary of the metric and their goal is provided, then
+        the goals are set.
+        """
+        self.dvh_metric_goals = defaultdict(float)
+        for dvh_name in self.dvh_metric_names:
+            self.dvh_metric_goals[dvh_name] = dvh_metric_goals.get(dvh_name, None)
 
     def get_dvh_metric(
         self,
@@ -121,7 +135,7 @@ class BrachyStructure:
         to BrachyStructure.dvh_metric_observed for backward compatibility (deprecated).
         """
         assert self.mask is not None, "mask is not loaded"
-        assert any(self.dvh_metric_goals), "dvh metric goals are not set"
+        assert any(self.dvh_metric_names), "dvh metric goals are not set"
         #assert (
         #    self.dvh_metric_clinical_goal is not None
         #), "dvh metric clinical goal is not set"
@@ -136,7 +150,7 @@ class BrachyStructure:
             )
         self.dvh_metrics_observed = {}
 
-        for dvh_metric_name in self.dvh_metric_goals.keys():
+        for dvh_metric_name in self.dvh_metric_names:
             metric_string = dvh_metric_name.split("(")[0]
 
             if metric_string.startswith("D"):

--- a/brachyutils/planning/structure_utils.py
+++ b/brachyutils/planning/structure_utils.py
@@ -40,7 +40,7 @@ class BrachyStructure:
         name: str = None,
         mask: ROIMask | ROIContour = None,
         is_target: bool = None,
-        in_dvh: bool = None,
+        in_dvh: bool = True,
         dvh_metric_goals: Dict[str, float] = None,
         optimization_config: Optimization_Config = None,
     ) -> None:
@@ -80,11 +80,9 @@ class BrachyStructure:
 
         # optimization attributes
         self.optimization_config: Optimization_Config = None
-        # self.optimization_dwell_coef_dict:Dict[str, np.array] = None XXX delete
         # self.optimization_mask: ROIMask = None
 
-        self.in_dvh = in_dvh
-        if self.in_dvh:
+        if self.in_dvh: # XXX figure out how to do this only optionally!
             if dvh_metric_goals is None:
                 raise ValueError(
                     """Please provide BrachyStructure with a dictionary of multiple metrics and goals"""

--- a/brachyutils/planning/structure_utils.py
+++ b/brachyutils/planning/structure_utils.py
@@ -41,6 +41,7 @@ class BrachyStructure:
         name: str,
         mask: ROIMask | ROIContour,
         dvh_metric_names: List[str] = None,
+        dvh_metric_goals: Dict[str, float] = None,
         is_target: bool = False,
         in_dvh: bool = True,
         optimization_config: Optimization_Config = None,
@@ -87,6 +88,9 @@ class BrachyStructure:
         # self.optimization_mask: ROIMask = None
         if dvh_metric_names is not None:
             self.set_dvh_metric_names(dvh_metric_names)
+
+        if dvh_metric_goals is not None:
+            self.dvh_metric_goals(dvh_metric_goals)
 
         if optimization_config is not None:
             self.set_optimization_config(optimization_config)

--- a/brachyutils/planning/structure_utils.py
+++ b/brachyutils/planning/structure_utils.py
@@ -39,8 +39,8 @@ class BrachyStructure:
     def __init__(
         self,
         name: str,
-        dvh_metric_names: List[str],
         mask: ROIMask | ROIContour,
+        dvh_metric_names: List[str] = None,
         is_target: bool = False,
         in_dvh: bool = True,
         optimization_config: Optimization_Config = None,
@@ -85,24 +85,43 @@ class BrachyStructure:
         # optimization attributes
         self.optimization_config: Optimization_Config = None
         # self.optimization_mask: ROIMask = None
+        if dvh_metric_names is not None:
+            self.set_dvh_metric_names(dvh_metric_names)
 
+        if optimization_config is not None:
+            self.set_optimization_config(optimization_config)
+
+    def set_dvh_metric_names(self, dvh_metric_names: List[str]):
+        r"""
+        ### Purpose:
+        - To set the DVH metric names for this structure.
+        ### Inputs:
+        - dvh_metric_names: List[str] := a list containing the DVH metrics for this structure. The names 
+        are of the format V_{#Gy|%}(organName), where # represents the numerical threshold and "|" is or.
+        For example D95%(organName).
+        ### Outputs:
+        - None:= will update self.dvh_metric_names
+        """
         assert np.all(
             [self.name.lower() in dvh_metric_name.lower()
             for dvh_metric_name in dvh_metric_names]),\
             "name should be in dvh metric name enclosed by paranthesis"
         self.dvh_metric_names = dvh_metric_names
 
-        if optimization_config is not None:
-            self.set_optimization_config(optimization_config)
-
-    def set_dvh_metric_goals(self, dvh_metric_goals: List[str] | Dict[str, float]):
+    def set_dvh_metric_goals(self, dvh_metric_goals: Dict[str, float]):
         r"""
         ### Purpose:
         - To set the DVH metrics or their goals for this structure.
-        If a list of strings is provided, then we only set the metrics.
-        If a dictionary of the metric and their goal is provided, then
-        the goals are set.
+        The keys should ideally match the self.dvh_metric_names.
+        if self.dvh_metric_names is None, this function sets the names based on the keys.
+        ### Inputs:
+        - dvh_metric_goals: Dict[str, float] := The dictionary mapping the DVH metric
+        names to their corresponding goal value. see self.set_dvh_metric_names() for 
+        the naming convention of the keys. 
         """
+        if self.dvh_metric_names is None:
+            self.set_dvh_metric_names(list(dvh_metric_goals.keys()))
+
         self.dvh_metric_goals = defaultdict(float)
         for dvh_name in self.dvh_metric_names:
             self.dvh_metric_goals[dvh_name] = dvh_metric_goals.get(dvh_name, None)

--- a/brachyutils/planning/structure_utils.py
+++ b/brachyutils/planning/structure_utils.py
@@ -106,10 +106,11 @@ class BrachyStructure:
         ### Outputs:
         - None:= will update self.dvh_metric_names
         """
-        assert np.all(
-            [self.name.lower() in dvh_metric_name.lower()
-            for dvh_metric_name in dvh_metric_names]),\
-            "name should be in dvh metric name enclosed by paranthesis"
+        # assert np.all( let's let go of this sanity check qnd favor chaotic progress over 
+        # orderly stagnation!
+        #     [self.name.lower() in dvh_metric_name.lower()
+        #     for dvh_metric_name in dvh_metric_names]),\
+        #     "name should be in dvh metric name enclosed by paranthesis"
         self.dvh_metric_names = dvh_metric_names
 
     def set_dvh_metric_goals(self, dvh_metric_goals: Dict[str, float]):

--- a/brachyutils/tests/test_plan_utils.py
+++ b/brachyutils/tests/test_plan_utils.py
@@ -27,7 +27,7 @@ def get_a_plan(
         dir_dicom=pth_dicom,
         load_dicom_dose=kwargs.get("load_dicom_dose", False),
         load_dicom_catheter_table=kwargs.get("load_dicom_catheter_table", True),
-        strict_name_match=False,
+        strict_name_match=kwargs.get("strict_name_match", False),
         from_delivered_dwellpositions=kwargs.get("from_delivered_dwellpositions", False),
         multi_processing=True,
         prescription_dose=prescription_dose,
@@ -100,8 +100,13 @@ def test_create_structures_and_calc_dvh_metrics():
 
     plan = get_a_plan(
         pth_dicom=dir_dicom,
-        prescription_dose=prescription_dose
+        prescription_dose=prescription_dose,
+        load_dicom_dose=True,
+        dvh_metric_goals=list(dvh_metric_goals.keys()),
+        strict_name_match=False,
     )
+    print("This is the loaded DVH metric goals")
+    print(plan.dvh_metric_goals)
     # pth_cathTable_dcm = list(Path(dir_dicom).glob("RP*.dcm"))[0]
     # dir_dose_rate = "data_test/prostate-glen-p1-dose"
     # # pth_dose = glob(dir_dicom + "/RD*.dcm")[0]

--- a/brachyutils/tests/test_plan_utils.py
+++ b/brachyutils/tests/test_plan_utils.py
@@ -8,7 +8,7 @@ import numpy as np
 from brachyutils.planning.plan_utils import BrachyPlan
 from brachyutils.planning.plan_utils import load_dicom_to_plan
 def get_a_plan(
-    pth_dicom:str | Path,
+    dir_dicom:str | Path,
     prescription_dose:float=21.0,
     **kwargs):
     dvh_metric_goals = {
@@ -24,7 +24,7 @@ def get_a_plan(
     }
 
     plan_obj = load_dicom_to_plan(
-        dir_dicom=pth_dicom,
+        dir_dicom=dir_dicom,
         load_dicom_dose=kwargs.get("load_dicom_dose", False),
         load_dicom_catheter_table=kwargs.get("load_dicom_catheter_table", True),
         strict_name_match=kwargs.get("strict_name_match", False),
@@ -64,8 +64,8 @@ def test_update_catheter_table_from_plan():
 
 def test_load_dose_rate_dict():
     from brachyutils.geometry.catheter_utils.catheter_table import CatheterTable
-    pth_dicom = "data_test/prostate-glen-p1-dcm"
-    pth_plan = glob(pth_dicom + "/RP*.dcm")[0]
+    dir_dicom = "data_test/prostate-glen-p1-dcm"
+    pth_plan = glob(dir_dicom + "/RP*.dcm")[0]
     dir_dose_rate = "data_test/prostate-glen-p1-dose"
 
     catheter_table = CatheterTable(
@@ -97,9 +97,14 @@ def test_create_structures_and_calc_dvh_metrics():
         "V150%(CTV)": prescription_dose * 0.4,
         "V100%(CTV)": 100.0,
     }
-
+    # load plan without dvh or dose
     plan = get_a_plan(
-        pth_dicom=dir_dicom,
+        dir_dicom=dir_dicom,
+        prescription_dose=prescription_dose,
+    )
+    # test with DVH names and dicom dose
+    plan = get_a_plan(
+        dir_dicom=dir_dicom,
         prescription_dose=prescription_dose,
         load_dicom_dose=True,
         dvh_metric_goals=list(dvh_metric_goals.keys()),
@@ -109,10 +114,34 @@ def test_create_structures_and_calc_dvh_metrics():
     print(plan.dvh_metric_goals)
     print(plan.get_dvh_metrics())
 
+    # test with DVH dict and dicom dose
+    plan = get_a_plan(
+        dir_dicom=dir_dicom,
+        prescription_dose=prescription_dose,
+        load_dicom_dose=True,
+        dvh_metric_goals=dvh_metric_goals,
+        strict_name_match=False,
+    )
+    print("This is the loaded DVH metric goals")
+    print(plan.dvh_metric_goals)
+    print(plan.get_dvh_metrics())
+
+    # test with DVH names and dose rates
+    plan = get_a_plan(
+        dir_dicom=dir_dicom,
+        prescription_dose=prescription_dose,
+        load_dicom_dose=False,
+        dvh_metric_goals=dvh_metric_goals,
+        strict_name_match=False,
+    )
+    print("This is the loaded DVH metric goals")
+    print(plan.dvh_metric_goals)
+    print(plan.get_dvh_metrics())
+
 def test_calculate_combined_uncertainty():
     from brachyutils.geometry.catheter_utils.catheter_table import CatheterTable
-    pth_dicom = "data_test/prostate-glen-p1-dcm"
-    pth_plan = glob(pth_dicom + "/RP*.dcm")[0]
+    dir_dicom = "data_test/prostate-glen-p1-dcm"
+    pth_plan = glob(dir_dicom + "/RP*.dcm")[0]
     dir_dose_rate = "data_test/prostate-glen-p1-dose"
 
     catheter_table = CatheterTable(
@@ -184,7 +213,7 @@ def test_BrachyPlan():
     )
 
 def test_export_brachy_plan():
-    pth_dicom = Path("data_test/prostate-glen-p1-dcm").resolve()
+    dir_dicom = Path("data_test/prostate-glen-p1-dcm").resolve()
     dir_export = Path("data_test/test_export_plan/prostate").resolve()
     target_dose = 21
     # # for loading the delivered dose rates. 
@@ -204,7 +233,7 @@ def test_export_brachy_plan():
     }
 
     plan:BrachyPlan = get_a_plan(
-        pth_dicom=pth_dicom,
+        dir_dicom=dir_dicom,
         dir_dose_rates=dir_dose_rates,
         from_delivered_dwellpositions=from_delivered_dwellpositions,
         generate_dose_rates=gen_dose_rates,
@@ -217,7 +246,7 @@ def test_export_brachy_plan():
 def test_load_brachy_plan_from_dicom():
     from brachyutils.geometry.phantom_utils import BrachyPhantom
 
-    pth_dicom = Path("data_test/prostate-glen-p1-dcm")
+    dir_dicom = Path("data_test/prostate-glen-p1-dcm")
     pth_dose_rates = Path("data_test/prostate-glen-p1-dose")
     dvh_metric_goals = {
         "D95%(ctv)": 21,
@@ -225,8 +254,8 @@ def test_load_brachy_plan_from_dicom():
         "D0.1cc(urethra)": 21*1.25,
     }
     brachy_phant = BrachyPhantom(
-        dir_dicom=pth_dicom,
-        pth_structures_file=list(pth_dicom.glob("RS*.dcm"))[0],
+        dir_dicom=dir_dicom,
+        pth_structures_file=list(dir_dicom.glob("RS*.dcm"))[0],
     )
     plan_obj = BrachyPlan(
         phantom=brachy_phant,
@@ -234,7 +263,7 @@ def test_load_brachy_plan_from_dicom():
         dvh_metric_goals=dvh_metric_goals,
         dir_dose_rate=pth_dose_rates,
         combined_dose_only=True,
-        catheter_table=list(pth_dicom.glob("RP*.dcm"))[0],
+        catheter_table=list(dir_dicom.glob("RP*.dcm"))[0],
         from_delivered_dwellpositions=True,
     )
     plan_obj.info()
@@ -279,9 +308,9 @@ def test_brachy_structure():
 
     from brachyutils import BrachyDose, BrachyPhantom, BrachyStructure
 
-    pth_dicom = "data_test/prostate-glen-p1-dcm/"
-    pth_structure = glob(pth_dicom + "/RS*.dcm")[0]
-    pth_dose = glob(pth_dicom + "/RD*.dcm")[0]
+    dir_dicom = "data_test/prostate-glen-p1-dcm/"
+    pth_structure = glob(dir_dicom + "/RS*.dcm")[0]
+    pth_dose = glob(dir_dicom + "/RD*.dcm")[0]
     dvh_metric_goals = {
         "D95%(ctv)": 15.,
         "D1cc(rectum)": 11.25,
@@ -289,7 +318,7 @@ def test_brachy_structure():
         "CI(ctv)": 100
     }
     dose = BrachyDose(pth_dose)
-    phantom_obj = BrachyPhantom(dir_dicom=pth_dicom, pth_structures_file=pth_structure)
+    phantom_obj = BrachyPhantom(dir_dicom=dir_dicom, pth_structures_file=pth_structure)
     mask_dict: dict = phantom_obj.get_structure_mask(phantom_obj.structure_names, ROIContour)
     for structure_name in mask_dict:
         mask_contour = mask_dict[structure_name]
@@ -317,7 +346,7 @@ def test_brachy_structure():
 def test_load_phantom():
     from pathlib import Path
 
-    pth_dicom = Path("data_test/prostate-glen-p1-dcm/")
+    dir_dicom = Path("data_test/prostate-glen-p1-dcm/")
 
     dvh_metric_goals = {
         "D95%(ctv)": 15,
@@ -325,7 +354,7 @@ def test_load_phantom():
         "D0.1cc(urethra)": 18.75,
     }
 
-    plan_obj = BrachyPlan(phantom=pth_dicom, dvh_metric_goals=dvh_metric_goals)
+    plan_obj = BrachyPlan(phantom=dir_dicom, dvh_metric_goals=dvh_metric_goals)
     plan_obj.info()
 
 if __name__ == "__main__":

--- a/brachyutils/tests/test_plan_utils.py
+++ b/brachyutils/tests/test_plan_utils.py
@@ -28,6 +28,7 @@ def get_a_plan(
         load_dicom_dose=kwargs.get("load_dicom_dose", False),
         load_dicom_catheter_table=kwargs.get("load_dicom_catheter_table", True),
         strict_name_match=kwargs.get("strict_name_match", False),
+        dir_dose_rate=kwargs.get("dir_dose_rate", None),
         from_delivered_dwellpositions=kwargs.get("from_delivered_dwellpositions", False),
         multi_processing=True,
         prescription_dose=prescription_dose,
@@ -85,6 +86,7 @@ def test_load_dose_rate_dict():
 
 def test_create_structures_and_calc_dvh_metrics():
     dir_dicom = "data_test/prostate-glen-p1-dcm"
+    dir_dose_rates = "data_test/prostate-glen-p1-dose"
     prescription_dose=21
     dvh_metric_goals = {
         "D90%(CTV)": prescription_dose,
@@ -133,6 +135,8 @@ def test_create_structures_and_calc_dvh_metrics():
         load_dicom_dose=False,
         dvh_metric_goals=dvh_metric_goals,
         strict_name_match=False,
+        dir_dose_rate=dir_dose_rates,
+        from_delivered_dwellpositions=False,
     )
     print("This is the loaded DVH metric goals")
     print(plan.dvh_metric_goals)

--- a/brachyutils/tests/test_plan_utils.py
+++ b/brachyutils/tests/test_plan_utils.py
@@ -31,7 +31,7 @@ def get_a_plan(
         from_delivered_dwellpositions=kwargs.get("from_delivered_dwellpositions", False),
         multi_processing=True,
         prescription_dose=prescription_dose,
-        dvh_metric_goals=dvh_metric_goals,
+        dvh_metric_goals=kwargs.get("dvh_metric_goals", None),
         optimization_config_list=kwargs.get("optimization_config_list", None),
         dwells_near_ptv=kwargs.get("dwells_near_ptv", True),
         add_hotspots_to_phantom=kwargs.get("add_hotspots_to_phantom", False),
@@ -85,30 +85,47 @@ def test_load_dose_rate_dict():
 
 def test_create_structures_and_calc_dvh_metrics():
     dir_dicom = "data_test/prostate-glen-p1-dcm"
-    pth_cathTable_dcm = list(Path(dir_dicom).glob("RP*.dcm"))[0]
-    dir_dose_rate = "data_test/prostate-glen-p1-dose"
-    # pth_dose = glob(dir_dicom + "/RD*.dcm")[0]
+    prescription_dose=21
     dvh_metric_goals = {
-        "D95%(ctv)": 15,
-        "D1cc(rectum)": 11.25,
-        "D0.1cc(urethra)": 18.75,
-        "CI(ctv)": 100,
-        "HI(ctv)": 0.5,
+        "D90%(CTV)": prescription_dose,
+        "D2cc(RECTUM)": prescription_dose * 0.75,
+        "D10%(URETHRA)": prescription_dose * 1.133,
+        "D30%(URETHRA)": prescription_dose,
+        "CI(CTV)": 1.0,
+        "HI(CTV)": 0.5,
+        "V200%(CTV)": prescription_dose * 0.2,
+        "V150%(CTV)": prescription_dose * 0.4,
+        "V100%(CTV)": 100.0,
     }
-    from time import time
-    t0 = time()
-    plan_obj = BrachyPlan(
-        phantom=dir_dicom,
-        dvh_metric_goals=dvh_metric_goals,
-        catheter_table=pth_cathTable_dcm,
-        # combined_dose=pth_dose,
-        dir_dose_rate=dir_dose_rate,
-        multi_processing=True,
-        combined_dose_only=True,
-        prescription_dose=21.,
+
+    plan = get_a_plan(
+        pth_dicom=dir_dicom,
+        prescription_dose=prescription_dose
     )
-    print(f"Loading the plan took {time()-t0} seconds")
-    print(plan_obj.get_dvh_metrics())
+    # pth_cathTable_dcm = list(Path(dir_dicom).glob("RP*.dcm"))[0]
+    # dir_dose_rate = "data_test/prostate-glen-p1-dose"
+    # # pth_dose = glob(dir_dicom + "/RD*.dcm")[0]
+    # dvh_metric_goals = {
+    #     "D95%(ctv)": 15,
+    #     "D1cc(rectum)": 11.25,
+    #     "D0.1cc(urethra)": 18.75,
+    #     "CI(ctv)": 100,
+    #     "HI(ctv)": 0.5,
+    # }
+    # from time import time
+    # t0 = time()
+    # plan_obj = BrachyPlan(
+    #     phantom=dir_dicom,
+    #     dvh_metric_goals=dvh_metric_goals,
+    #     catheter_table=pth_cathTable_dcm,
+    #     # combined_dose=pth_dose,
+    #     dir_dose_rate=dir_dose_rate,
+    #     multi_processing=True,
+    #     combined_dose_only=True,
+    #     prescription_dose=21.,
+    # )
+    # print(f"Loading the plan took {time()-t0} seconds")
+    # print(plan_obj.get_dvh_metrics())
     
 
 
@@ -335,10 +352,10 @@ if __name__ == "__main__":
     # testupdate_plan_from_catheter_table()
     # test_update_catheter_table_from_plan()
     # test_load_dose_rate_dict()
-    # test_create_structures_and_calc_dvh_metrics()
+    test_create_structures_and_calc_dvh_metrics()
     # test_calculate_combined_uncertainty()
     # test_calculate_uncertainty_per_structure()
-    test_BrachyPlan()
+    # test_BrachyPlan()
     # test__load_single_dose_or_uncertainty_to_dict()
     # test_export_brachy_plan()
     # test_load_brachy_plan_from_dicom()

--- a/brachyutils/tests/test_plan_utils.py
+++ b/brachyutils/tests/test_plan_utils.py
@@ -107,32 +107,7 @@ def test_create_structures_and_calc_dvh_metrics():
     )
     print("This is the loaded DVH metric goals")
     print(plan.dvh_metric_goals)
-    # pth_cathTable_dcm = list(Path(dir_dicom).glob("RP*.dcm"))[0]
-    # dir_dose_rate = "data_test/prostate-glen-p1-dose"
-    # # pth_dose = glob(dir_dicom + "/RD*.dcm")[0]
-    # dvh_metric_goals = {
-    #     "D95%(ctv)": 15,
-    #     "D1cc(rectum)": 11.25,
-    #     "D0.1cc(urethra)": 18.75,
-    #     "CI(ctv)": 100,
-    #     "HI(ctv)": 0.5,
-    # }
-    # from time import time
-    # t0 = time()
-    # plan_obj = BrachyPlan(
-    #     phantom=dir_dicom,
-    #     dvh_metric_goals=dvh_metric_goals,
-    #     catheter_table=pth_cathTable_dcm,
-    #     # combined_dose=pth_dose,
-    #     dir_dose_rate=dir_dose_rate,
-    #     multi_processing=True,
-    #     combined_dose_only=True,
-    #     prescription_dose=21.,
-    # )
-    # print(f"Loading the plan took {time()-t0} seconds")
-    # print(plan_obj.get_dvh_metrics())
-    
-
+    print(plan.get_dvh_metrics())
 
 def test_calculate_combined_uncertainty():
     from brachyutils.geometry.catheter_utils.catheter_table import CatheterTable


### PR DESCRIPTION
The users can now load a BrachyPlan from without providing the DVH metric goals. If they decide to use the DVH metric goals, they can provide it as the following options:
1. DVH metric goal is a list of string containing the DVHs for all of the structures. strict or loose name matching is possible.
2. DVH metric goal is a dictionary mapping each DVH metric to its desired clinical threshold.
3. a string or a Path pointing to the json file with either of the options above.

Inside the plan, the DVH metric goals dictionary uses the names of the structures in the phantom as its keys. For its values, it has either the list of the  DVH metrics or a dictionary for DVH metrics and their goals.

