### PR TITLE
Exclusive plan structures

### DIFF
--- a/brachyutils/planning/plan_utils.py
+++ b/brachyutils/planning/plan_utils.py
@@ -532,15 +532,19 @@ class BrachyPlan:
         )->None:
         r"""
         ### Purpose:
-        - To create a list of BrachyStructure objects from the structures in the phantom and
-        the DVH metric goals. Each BrachyStructure object will have attributes for the structure
-        contour, the DVH and uncertainty volume histograms, optimization attributes, and simulation attributes.
+        - To create a list of BrachyStructure objects from the structures in the phantom.
+        Each BrachyStructure object will have attributes for the structure
+        contour, the DVH and uncertainty volume histograms, optimization attributes,
+        and simulation attributes. Here, we only set the mask. We also ensure that there is
+        no overlap between the mask of the target structure and the OARs, priority is given
+        to OAR.
 
         ### Inputes:
         - phantom := the phantom with its structures fully loaded.
         - dvh_metric_goals := the dvh metric goals dictionary
         - mask_type: ROIContour | ROIMask := Phantom masks will be converted to this type when being
         stored in BrachySturucture.
+
         ### Outputs:
         - None := will update the BrachyPlan.structure_list attribute
         """
@@ -566,17 +570,24 @@ class BrachyPlan:
             mask_type=ROIContour,
             strict_name_match=False,).get("body", None)
 
-        # XXX: Delete this!
-        # if phantom.cached_structure_masks is not None:
-        #     body_key = None
-        #     for k in phantom.cached_structure_masks.keys():
-        #         if k.lower() == "body":
-        #             body_key = k
-        #     self.body_contour = phantom.cached_structure_masks.get(body_key, None)
-        # else:
-        #     self.body_contour = phantom.get_structure_mask(
-        #         ["body"], ROIContour, strict_name_match=False
-        #     ).get("body", None)
+        # If there is an OAR that goes through the PTV, cut it out of PTV.
+        # this is because each voxel can have planning role only.
+        # in prostate, the urethra goes through the PTV.
+        target_structure = next(filter(lambda x: x.is_target, self.structure_list))
+        for structure in self.structure_list:
+            if structure.is_target:
+                continue
+            if "body" in structure.name.lower():
+                continue 
+            # find intersection between this structure and target_structure
+            overlap = (
+                target_structure.mask.imageArray 
+                &  structure.mask.imageArray)
+            if np.any(overlap):
+                target_structure.mask.imageArray = (
+                    target_structure.mask.imageArray 
+                    & (np.ma.ones_like(overlap)^overlap))
+
 
     def load_applicator_list(
         self,

--- a/brachyutils/tests/test_plan_utils.py
+++ b/brachyutils/tests/test_plan_utils.py
@@ -7,6 +7,7 @@ import numpy as np
 
 from brachyutils.planning.plan_utils import BrachyPlan
 from brachyutils.planning.plan_utils import load_dicom_to_plan
+from brachyutils.geometry.phantom_utils import masksToNrrd
 def get_a_plan(
     dir_dicom:str | Path,
     **kwargs)->BrachyPlan:
@@ -86,6 +87,7 @@ def test_load_dose_rate_dict():
         "data_test/test_export_plan/prostate/new_cathtabel.json")
 
 def test_create_structures_and_calc_dvh_metrics():
+    dir_out = Path("data_test/test_export_plan/prostate")
     dir_dicom = "data_test/prostate-glen-p1-dcm"
     dir_dose_rate = "data_test/prostate-glen-p1-dose"
     prescription_dose=21
@@ -116,7 +118,11 @@ def test_create_structures_and_calc_dvh_metrics():
     print("This is the loaded DVH metric goals")
     print(plan.dvh_metric_goals)
     print(plan.get_dvh_metrics())
-
+    masksToNrrd(
+        structure_mask_dict={structure.name:structure.mask for structure in plan.structure_list},
+        pth_output=dir_out/"non-overlapping-structures.seg.nrrd"
+    )
+    return
     # test with DVH dict and dicom dose
     plan = get_a_plan(
         dir_dicom=dir_dicom,


### PR DESCRIPTION
In case an OAR collides with the target volume, we cut out the OAR out of the target volume only in the planning structures. This prevents a voxel in the OAR to be included in the optimization model as a target voxel.

<img width="692" height="451" alt="image" src="https://github.com/user-attachments/assets/57ec51db-6419-4c90-a5f6-553a917ce323" />
